### PR TITLE
feat: add combined filter for improved suggestions

### DIFF
--- a/pkg/prompt/goprompt/filterranked.go
+++ b/pkg/prompt/goprompt/filterranked.go
@@ -1,0 +1,34 @@
+package goprompt
+
+// FilterRanked combines prefix, contains, and fuzzy filters in that order to create suggestions that
+// consider the most relevant matches first.
+func filterCombined(completions []Suggest, sub string, ignoreCase bool) []Suggest {
+	prefixMatches := FilterHasPrefix(completions, sub, ignoreCase)
+	containsMatches := FilterContains(completions, sub, ignoreCase)
+	fuzzyMatches := FilterFuzzy(completions, sub, ignoreCase)
+
+	// combine all matches, ensuring no duplicates
+	presenseSet := make(map[string]Suggest)
+
+	res := make([]Suggest, 0, len(prefixMatches)+len(containsMatches)+len(fuzzyMatches))
+
+	for _, match := range prefixMatches {
+		presenseSet[match.Text] = match
+		res = append(res, match)
+	}
+
+	for _, match := range containsMatches {
+		if _, exists := presenseSet[match.Text]; !exists {
+			presenseSet[match.Text] = match
+			res = append(res, match)
+		}
+	}
+
+	for _, match := range fuzzyMatches {
+		if _, exists := presenseSet[match.Text]; !exists {
+			res = append(res, match)
+		}
+	}
+
+	return res
+}

--- a/pkg/prompt/goprompt/types.go
+++ b/pkg/prompt/goprompt/types.go
@@ -16,4 +16,5 @@ var (
 	FilterContains  = prompt.FilterContains
 	FilterHasPrefix = prompt.FilterHasPrefix
 	FilterHasSuffix = prompt.FilterHasSuffix
+	FilterCombined  = filterCombined
 )

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -150,7 +150,7 @@ func New(l log.Logger, opts ...Option) (*Prompt, error) {
 		prefix:    "› ",
 		prefixGit: false,
 		flair:     flair.DefaultFlair,
-		filter:    goprompt.FilterFuzzy,
+		filter:    goprompt.FilterCombined,
 		check:     check.DefaultCheck,
 		history:   history.NewNoop(l),
 		commands:  command.Commands{},


### PR DESCRIPTION
### Type of Change
- [ x ] New feature

### Description
Added a new default filter for suggestions. This filter attempts to solve a common UX issue when using autosuggest in posh by preferring prefixed values and direct contains to fuzzy search while still including fuzzy search results. This is achieved by running all three filters in parallel and then merging the results in that order of priority. 

### Related Issue
_[If this pull request addresses an issue, please link to it here (e.g., Fixes #123).]_

### Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ x ] I have performed a self-review of my own code.
- [ x  ] I have commented my code, particularly in hard-to-understand areas.
- [ x  ] I have made corresponding changes to the documentation.
