### PR TITLE
feat: completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ test.demo: install
 	@cd tmp/test && \
 		git init . && \
 		git remote add origin https://github.com/foomo/posh-test-demo && \
+		touch README.md && git add README.md && git commit -m "initial commit" && \
 		posh init && \
 		echo "replace github.com/foomo/posh => ../../../" >> .posh/go.mod && \
 		make shell.build && \

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,6 @@ test.demo: install
 	@cd tmp/test && \
 		git init . && \
 		git remote add origin https://github.com/foomo/posh-test-demo && \
-		touch README.md && git add README.md && git commit -m "initial commit" && \
 		posh init && \
 		echo "replace github.com/foomo/posh => ../../../" >> .posh/go.mod && \
 		make shell.build && \

--- a/cmd/brew.go
+++ b/cmd/brew.go
@@ -13,6 +13,7 @@ func NewBrew(root *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:           "brew",
 		Short:         "Check and install required packages.",
+		Aliases:       []string{"i"},
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -13,6 +13,7 @@ func NewExecute(root *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:                "execute",
 		Short:              "Execute a single Project Oriented Shell command",
+		Aliases:            []string{"x"},
 		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
 		SilenceUsage:       true,

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	intcmd "github.com/foomo/posh/internal/cmd"
 	intconfig "github.com/foomo/posh/internal/config"
+	"github.com/foomo/posh/pkg/plugin"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -37,6 +38,24 @@ func NewExecute(root *cobra.Command) {
 			}
 
 			return plg.Execute(cmd.Context(), args)
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			l := intcmd.NewLogger()
+			if err := intconfig.Load(l); err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			plg, err := pluginProvider(l)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+
+			completer, ok := plg.(plugin.Completer)
+			if !ok {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			return completer.Complete(cmd.Context(), args, toComplete), cobra.ShellCompDirectiveNoFileComp
 		},
 	}
 

--- a/embed/scaffold/init/$.posh/internal/plugin.go.gotext
+++ b/embed/scaffold/init/$.posh/internal/plugin.go.gotext
@@ -10,6 +10,7 @@ import (
 	ownbrewconfig "github.com/foomo/ownbrew/pkg/config"
 	"github.com/foomo/ownbrew/pkg/ownbrew"
 	"github.com/foomo/posh/pkg/command"
+	"github.com/foomo/posh/pkg/complete"
 	"github.com/foomo/posh/pkg/config"
 	"github.com/foomo/posh/pkg/log"
 	"github.com/foomo/posh/pkg/plugin"
@@ -74,6 +75,10 @@ func (p *Plugin) Require(ctx context.Context, cfg config.Require) error {
 		require.Packages(p.l, cfg.Packages),
 		require.Scripts(p.l, cfg.Scripts),
 	)
+}
+
+func (p *Plugin) Complete(ctx context.Context, args []string, toComplete string) []string {
+	return complete.Suggest(ctx, p.l, p.commands, args, toComplete)
 }
 
 func (p *Plugin) Execute(ctx context.Context, args []string) error {

--- a/pkg/complete/complete.go
+++ b/pkg/complete/complete.go
@@ -1,0 +1,73 @@
+// Package complete produces shell-completion suggestions for `posh execute`
+// invocations by reusing the same readline-driven dispatch that the
+// interactive prompt uses.
+package complete
+
+import (
+	"context"
+	"strings"
+
+	"github.com/foomo/posh/pkg/command"
+	"github.com/foomo/posh/pkg/log"
+	"github.com/foomo/posh/pkg/prompt/goprompt"
+	"github.com/foomo/posh/pkg/readline"
+)
+
+// Suggest parses (args, toComplete) into a readline state, dispatches to the
+// matching command's completer interface, and returns suggestions in cobra's
+// `value\tdescription` format. Suggestions are prefix-filtered by toComplete.
+func Suggest(ctx context.Context, l log.Logger, cmds command.Commands, args []string, toComplete string) []string {
+	r, err := readline.New(l)
+	if err != nil {
+		return nil
+	}
+
+	input := strings.Join(append(append([]string{}, args...), toComplete), " ")
+	if err := r.Parse(input); err != nil {
+		return nil
+	}
+
+	var suggests []goprompt.Suggest
+
+	if r.IsModeDefault() && r.Args().LenIs(0) {
+		for _, inst := range cmds.List() {
+			suggests = append(suggests, goprompt.Suggest{Text: inst.Name(), Description: inst.Description()})
+		}
+	} else if cmd := cmds.Get(r.Cmd()); cmd != nil {
+		switch r.Mode() {
+		case readline.ModeArgs:
+			if v, ok := cmd.(command.ArgumentCompleter); ok {
+				suggests = v.CompleteArguments(ctx, r)
+			} else if v, ok := cmd.(command.Completer); ok {
+				suggests = v.Complete(ctx, r)
+			}
+		case readline.ModeFlags:
+			if v, ok := cmd.(command.FlagCompleter); ok {
+				suggests = v.CompleteFlags(ctx, r)
+			} else if v, ok := cmd.(command.Completer); ok {
+				suggests = v.Complete(ctx, r)
+			}
+		case readline.ModeAdditionalArgs:
+			if v, ok := cmd.(command.AdditionalArgsCompleter); ok {
+				suggests = v.CompleteAdditionalArgs(ctx, r)
+			} else if v, ok := cmd.(command.Completer); ok {
+				suggests = v.Complete(ctx, r)
+			}
+		}
+	}
+
+	out := make([]string, 0, len(suggests))
+	for _, s := range suggests {
+		if toComplete != "" && !strings.HasPrefix(s.Text, toComplete) {
+			continue
+		}
+
+		if s.Description != "" {
+			out = append(out, s.Text+"\t"+s.Description)
+		} else {
+			out = append(out, s.Text)
+		}
+	}
+
+	return out
+}

--- a/pkg/complete/complete_test.go
+++ b/pkg/complete/complete_test.go
@@ -1,0 +1,148 @@
+package complete_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/foomo/posh/pkg/command"
+	"github.com/foomo/posh/pkg/complete"
+	"github.com/foomo/posh/pkg/log"
+	"github.com/foomo/posh/pkg/prompt/goprompt"
+	"github.com/foomo/posh/pkg/readline"
+	"github.com/stretchr/testify/assert"
+)
+
+type testCmd struct {
+	name        string
+	description string
+	args        []goprompt.Suggest
+	flags       []goprompt.Suggest
+	addl        []goprompt.Suggest
+	generic     []goprompt.Suggest
+}
+
+func (c *testCmd) Name() string        { return c.name }
+func (c *testCmd) Description() string { return c.description }
+func (c *testCmd) Execute(ctx context.Context, r *readline.Readline) error {
+	return nil
+}
+
+type withArgs struct{ *testCmd }
+
+func (c *withArgs) CompleteArguments(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
+	return c.args
+}
+
+type withFlags struct{ *testCmd }
+
+func (c *withFlags) CompleteFlags(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
+	return c.flags
+}
+
+type withAdditional struct{ *testCmd }
+
+func (c *withAdditional) CompleteAdditionalArgs(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
+	return c.addl
+}
+
+type withGeneric struct{ *testCmd }
+
+func (c *withGeneric) Complete(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
+	return c.generic
+}
+
+func newLogger(t *testing.T) log.Logger {
+	t.Helper()
+	return log.NewTest(t, log.TestWithLevel(log.LevelInfo))
+}
+
+func TestSuggest_RootListsCommands(t *testing.T) {
+	cmds := command.Commands{}
+	cmds.Add(&testCmd{name: "alpha", description: "first"})
+	cmds.Add(&testCmd{name: "beta", description: "second"})
+
+	got := complete.Suggest(t.Context(), newLogger(t), cmds, nil, "")
+
+	assert.Equal(t, []string{"alpha\tfirst", "beta\tsecond"}, got)
+}
+
+func TestSuggest_RootPrefixFilter(t *testing.T) {
+	cmds := command.Commands{}
+	cmds.Add(&testCmd{name: "alpha", description: "first"})
+	cmds.Add(&testCmd{name: "alphabet", description: "longer"})
+	cmds.Add(&testCmd{name: "beta", description: "second"})
+
+	got := complete.Suggest(t.Context(), newLogger(t), cmds, nil, "alph")
+
+	assert.Equal(t, []string{"alpha\tfirst", "alphabet\tlonger"}, got)
+}
+
+func TestSuggest_RootOmitsDescriptionWhenEmpty(t *testing.T) {
+	cmds := command.Commands{}
+	cmds.Add(&testCmd{name: "bare"})
+
+	got := complete.Suggest(t.Context(), newLogger(t), cmds, nil, "")
+
+	assert.Equal(t, []string{"bare"}, got)
+}
+
+func TestSuggest_ArgumentCompleterDispatch(t *testing.T) {
+	cmd := &withArgs{testCmd: &testCmd{
+		name: "foo",
+		args: []goprompt.Suggest{{Text: "one", Description: "1st"}, {Text: "two"}},
+	}}
+	cmds := command.Commands{}
+	cmds.Add(cmd)
+
+	got := complete.Suggest(t.Context(), newLogger(t), cmds, []string{"foo"}, "")
+
+	assert.Equal(t, []string{"one\t1st", "two"}, got)
+}
+
+func TestSuggest_ArgumentCompleterPrefixFilter(t *testing.T) {
+	cmd := &withArgs{testCmd: &testCmd{
+		name: "foo",
+		args: []goprompt.Suggest{{Text: "one"}, {Text: "onyx"}, {Text: "two"}},
+	}}
+	cmds := command.Commands{}
+	cmds.Add(cmd)
+
+	got := complete.Suggest(t.Context(), newLogger(t), cmds, []string{"foo"}, "on")
+
+	assert.Equal(t, []string{"one", "onyx"}, got)
+}
+
+func TestSuggest_GenericCompleterFallback(t *testing.T) {
+	cmd := &withGeneric{testCmd: &testCmd{
+		name:    "foo",
+		generic: []goprompt.Suggest{{Text: "g1"}},
+	}}
+	cmds := command.Commands{}
+	cmds.Add(cmd)
+
+	got := complete.Suggest(t.Context(), newLogger(t), cmds, []string{"foo"}, "")
+
+	assert.Equal(t, []string{"g1"}, got)
+}
+
+func TestSuggest_FlagCompleterDispatch(t *testing.T) {
+	cmd := &withFlags{testCmd: &testCmd{
+		name:  "foo",
+		flags: []goprompt.Suggest{{Text: "--bar"}, {Text: "--baz"}},
+	}}
+	cmds := command.Commands{}
+	cmds.Add(cmd)
+
+	got := complete.Suggest(t.Context(), newLogger(t), cmds, []string{"foo"}, "--")
+
+	assert.Equal(t, []string{"--bar", "--baz"}, got)
+}
+
+func TestSuggest_UnknownCommandReturnsEmpty(t *testing.T) {
+	cmds := command.Commands{}
+	cmds.Add(&testCmd{name: "foo"})
+
+	got := complete.Suggest(t.Context(), newLogger(t), cmds, []string{"nope"}, "")
+
+	assert.Empty(t, got)
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -13,3 +13,10 @@ type Plugin interface {
 	Brew(ctx context.Context, cfg ownbrewconfig.Config, tags []string, dry bool) error
 	Require(ctx context.Context, cfg config.Require) error
 }
+
+// Completer is an optional Plugin extension that produces shell completion
+// suggestions for `posh execute`. Returned strings use the cobra format:
+// "value\tdescription" (description optional).
+type Completer interface {
+	Complete(ctx context.Context, args []string, toComplete string) []string
+}


### PR DESCRIPTION
### Description

Add shell completion support for `posh execute`. Downstream plugins implementing the optional `plugin.Completer` interface get cobra-driven tab completion for subcommands, flags, and arguments. New `pkg/complete` package provides reusable completion helpers.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/CI

### Changes

- `pkg/plugin`: add optional `Completer` interface (`Complete(ctx, args, toComplete) []string`) using cobra's `value\tdescription` format
- `cmd/execute.go`: wire `ValidArgsFunction` to delegate to plugin's `Completer` when implemented
- `pkg/complete`: new package with completion helpers + tests
- `embed/scaffold/init/$.posh/internal/plugin.go.gotext`: scaffold updated to expose completer
- `Makefile`: supporting target update

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.