### PR TITLE
feat: add history search

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -26,6 +26,7 @@ prompt:
     limit: 100                # max lines kept in the history file
     filename: .posh/.history
     lockFilename: .posh/.history.lock
+  historySearch: true         # enable Ctrl+R fuzzy history search
   aliases:
     k: kubectl
     gco: git checkout
@@ -39,6 +40,7 @@ prompt:
 | `history.limit` | int | Lines retained on disk. |
 | `history.filename` | string | Relative to `${PROJECT_ROOT}`. |
 | `history.lockFilename` | string | Lock file for concurrent shells. |
+| `historySearch` | bool | If true, `Ctrl+R` opens fuzzy history search (see [Prompt → History search](/usage/prompt#history-search)). |
 | `aliases` | map[string]string | Longest-prefix substitution. Suggested on `<Tab>`. |
 
 ## `env`

--- a/docs/usage/prompt.md
+++ b/docs/usage/prompt.md
@@ -43,6 +43,10 @@ posh › history
 
 The `history` command is added automatically whenever a non-noop history is configured.
 
+### History search
+
+Set `prompt.historySearch: true` in `.posh.yaml` to enable incremental fuzzy search over the history file. Press `Ctrl+R` from the prompt to swap the buffer to a `⏩︎` marker; subsequent keystrokes filter previous entries via `lithammer/fuzzysearch` and surface up to 10 suggestions, deduplicated and listed newest-first. Select one with `<Tab>`/`<Enter>` to run it — the marker is stripped before execution. Backspace through the marker (or clear the line) to leave the search mode.
+
 ## Aliases
 
 Aliases are longest-prefix string substitutions defined in `.posh.yaml`:
@@ -64,6 +68,7 @@ Typing `gco main` is rewritten to `git checkout main` before the line is parsed,
 | `Ctrl+C` | Cancels the **active command** (its `ctx.Done()` fires). The prompt itself stays open. |
 | `Ctrl+D` / `exit` | Cleanly exits the prompt. Triggers `Shutdown(ctx)` on every command implementing `Shutdowner`, with a 3-second deadline. |
 | `Ctrl+L` | Clears the screen. |
+| `Ctrl+R` | Opens fuzzy [history search](#history-search) when `prompt.historySearch: true`. |
 | `Alt+←` / `Alt+→` | Word-wise cursor movement (the macOS bindings are wired for you). |
 
 The shutdown phase is parallel: every `Shutdowner` runs in its own goroutine inside an `errgroup`. If any returns an error, the prompt exits with a non-zero status. If a shutdown exceeds 3 seconds, the parent context is cancelled — your handlers should respect that.

--- a/embed/scaffold/init/$.posh.yaml
+++ b/embed/scaffold/init/$.posh.yaml
@@ -10,6 +10,7 @@ prompt:
     limit: 100
     filename: .posh/.history
     lockFilename: .posh/.history.lock
+  historySearch: true
 
 ## Environment variables
 env:

--- a/embed/scaffold/init/$.posh/internal/command/welcome.go.gotext
+++ b/embed/scaffold/init/$.posh/internal/command/welcome.go.gotext
@@ -71,7 +71,7 @@ func (c *Welcome) Execute(ctx context.Context, r *readline.Readline) error {
 	return nil
 }
 
-func (c *Welcome) Help() string {
+func (c *Welcome) Help(ctx context.Context, r *readline.Readline) string {
 	return `Print a welcome message
 
 Usage:

--- a/embed/scaffold/init/$.posh/internal/plugin.go.gotext
+++ b/embed/scaffold/init/$.posh/internal/plugin.go.gotext
@@ -129,6 +129,7 @@ func (p *Plugin) Prompt(ctx context.Context, cfg config.Prompt) error {
 			history.FileWithFilename(cfg.History.Filename),
 			history.FileWithLockFilename(cfg.History.LockFilename),
 		),
+		prompt.WithHistorySearch(cfg.HistorySearch),
 	)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -16,13 +16,14 @@ require (
 	github.com/c-bata/go-prompt v0.2.6
 	github.com/charlievieth/fastwalk v1.0.14
 	github.com/foomo/fender v1.1.0
-	github.com/foomo/go v0.11.0
+	github.com/foomo/go v0.12.0
 	github.com/foomo/ownbrew v0.3.0
 	github.com/go-git/go-git/v6 v6.0.0-alpha.4
 	github.com/gofrs/flock v0.13.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/joho/godotenv v1.5.1
 	github.com/kubescape/go-git-url v0.0.32
+	github.com/lithammer/fuzzysearch v1.1.8
 	github.com/neilotoole/slogt v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/pterm/pterm v0.12.83
@@ -69,7 +70,6 @@ require (
 	github.com/kevinburke/ssh_config v1.6.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/foomo/fender v1.1.0 h1:iWlLjAhIuofKuo2DFpQvnLU78VNjK7nuVbXTmpHO2jw=
 github.com/foomo/fender v1.1.0/go.mod h1:Ufk4NLv4bgBihcUd9w//AatADC8bIPT+HNHLU7k8IyI=
-github.com/foomo/go v0.11.0 h1:YSKHryh9+F/b9NKxmwySZGYdzINsNZNFHwaGZU3pmng=
-github.com/foomo/go v0.11.0/go.mod h1:jeSB/atkoqSoJ3+ak0+b/Xtj7IMyDj1odzJroudT7Dw=
+github.com/foomo/go v0.12.0 h1:Y5mKeLVll1yzM8UGsPdNc/z7Rrr4J7QVwNVO65ZbnE0=
+github.com/foomo/go v0.12.0/go.mod h1:jeSB/atkoqSoJ3+ak0+b/Xtj7IMyDj1odzJroudT7Dw=
 github.com/foomo/ownbrew v0.3.0 h1:MQQt6DF4o7dScHm9oxshhNEgFpUfymGctgdJim37r7s=
 github.com/foomo/ownbrew v0.3.0/go.mod h1:Lq9AC0lteflKj0/OBoZThoK5yMVu+nmI1ZM/iJfApFQ=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/pkg/config/prompt.go
+++ b/pkg/config/prompt.go
@@ -2,11 +2,12 @@ package config
 
 type (
 	Prompt struct {
-		Title     string            `json:"title" yaml:"title"`
-		Prefix    string            `json:"prefix" yaml:"prefix"`
-		PrefixGit bool              `json:"prefixGit" yaml:"prefixGit"`
-		History   PromptHistory     `json:"history" yaml:"history"`
-		Aliases   map[string]string `json:"aliases" yaml:"aliases"`
+		Title         string            `json:"title" yaml:"title"`
+		Prefix        string            `json:"prefix" yaml:"prefix"`
+		PrefixGit     bool              `json:"prefixGit" yaml:"prefixGit"`
+		History       PromptHistory     `json:"history" yaml:"history"`
+		HistorySearch bool              `json:"historySearch" yaml:"historySearch"`
+		Aliases       map[string]string `json:"aliases" yaml:"aliases"`
 	}
 	PromptHistory struct {
 		Limit        int    `json:"limit" yaml:"limit"`

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -2,6 +2,7 @@ package prompt
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"time"
 
@@ -18,24 +19,31 @@ import (
 	"github.com/foomo/posh/pkg/shell"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/lithammer/fuzzysearch/fuzzy"
 	"golang.org/x/sync/errgroup"
+)
+
+const (
+	historySearchPrefix     = "⏩︎"
+	historySearchMaxResults = 10
 )
 
 type (
 	Prompt struct {
-		l         log.Logger
-		ctx       context.Context
-		title     string
-		flair     flair.Flair
-		prefix    string
-		prefixGit bool
-		check     check.Check
-		checkers  check.Checkers
-		filter    goprompt.Filter
-		readline  *readline.Readline
-		history   history.History
-		commands  command.Commands
-		aliases   map[string]string
+		l             log.Logger
+		ctx           context.Context
+		title         string
+		flair         flair.Flair
+		prefix        string
+		prefixGit     bool
+		check         check.Check
+		checkers      check.Checkers
+		filter        goprompt.Filter
+		readline      *readline.Readline
+		history       history.History
+		historySearch bool
+		commands      command.Commands
+		aliases       map[string]string
 		// inputRegex - split cmd into args
 		promptOptions []prompt.Option
 	}
@@ -141,6 +149,13 @@ func WithPromptOptions(v ...prompt.Option) Option {
 	}
 }
 
+func WithHistorySearch(v bool) Option {
+	return func(o *Prompt) error {
+		o.historySearch = v
+		return nil
+	}
+}
+
 // ------------------------------------------------------------------------------------------------
 // ~ Constructor
 // ------------------------------------------------------------------------------------------------
@@ -198,76 +213,82 @@ func (s *Prompt) Run() error {
 		return err
 	}
 
+	baseOptions := []prompt.Option{
+		prompt.OptionTitle(s.title),
+		prompt.OptionPrefix(s.prefix),
+		prompt.OptionLivePrefix(func() (string, bool) {
+			if s.prefixGit {
+				r, err := git.PlainOpenWithOptions(env.ProjectRoot(), &git.PlainOpenOptions{})
+				if err != nil {
+					s.l.Debug("failed to open git repository", "error", err)
+				}
+
+				ref, err := r.Head()
+				if err != nil {
+					s.l.Debug("failed to fetch HEAD", "error", err)
+				}
+
+				if ref == nil {
+					return s.prefix, false
+				}
+
+				name := ref.Name().Short()
+				if !ref.Name().IsBranch() {
+					name = ref.Hash().String()[:7]
+				}
+
+				var tags []string
+
+				if t, err := r.Tags(); err == nil {
+					_ = t.ForEach(func(reference *plumbing.Reference) error {
+						if ref.Hash() == reference.Hash() {
+							tags = append(tags, reference.Name().Short())
+						}
+
+						return nil
+					})
+				}
+
+				if len(tags) > 0 {
+					name += " ∘ " + strings.Join(tags, ", ")
+				}
+
+				return s.prefix[:len(s.prefix)-4] + "(" + name + ") › ", true
+			}
+
+			return "", false
+		}),
+		prompt.OptionPrefixTextColor(prompt.Cyan),
+		prompt.OptionInputTextColor(prompt.DefaultColor),
+		prompt.OptionCompletionWordSeparator(completer.FilePathCompletionSeparator),
+		prompt.OptionHistoryIgnoreDuplicates(),
+		prompt.OptionSetExitCheckerOnInput(func(in string, breakline bool) bool {
+			return breakline && in == "exit"
+		}),
+		prompt.OptionHistory(histories),
+		// macos alt+left fix
+		prompt.OptionAddASCIICodeBind(prompt.ASCIICodeBind{
+			ASCIICode: []byte{0x1b, 0x62},
+			Fn:        prompt.GoLeftWord,
+		}),
+		// macos alt+right fix
+		prompt.OptionAddASCIICodeBind(prompt.ASCIICodeBind{
+			ASCIICode: []byte{0x1b, 0x66},
+			Fn:        prompt.GoRightWord,
+		}),
+	}
+
+	if s.historySearch {
+		baseOptions = append(baseOptions, prompt.OptionAddKeyBind(prompt.KeyBind{
+			Key: prompt.ControlR,
+			Fn:  s.activateHistorySearch,
+		}))
+	}
+
 	p := prompt.New(
 		s.execute,
 		s.complete,
-		append(
-			[]prompt.Option{
-				prompt.OptionTitle(s.title),
-				prompt.OptionPrefix(s.prefix),
-				prompt.OptionLivePrefix(func() (string, bool) {
-					if s.prefixGit {
-						r, err := git.PlainOpenWithOptions(env.ProjectRoot(), &git.PlainOpenOptions{})
-						if err != nil {
-							s.l.Debug("failed to open git repository", "error", err)
-						}
-
-						ref, err := r.Head()
-						if err != nil {
-							s.l.Debug("failed to fetch HEAD", "error", err)
-						}
-
-						if ref == nil {
-							return s.prefix, false
-						}
-
-						name := ref.Name().Short()
-						if !ref.Name().IsBranch() {
-							name = ref.Hash().String()[:7]
-						}
-
-						var tags []string
-
-						if t, err := r.Tags(); err == nil {
-							_ = t.ForEach(func(reference *plumbing.Reference) error {
-								if ref.Hash() == reference.Hash() {
-									tags = append(tags, reference.Name().Short())
-								}
-
-								return nil
-							})
-						}
-
-						if len(tags) > 0 {
-							name += " ∘ " + strings.Join(tags, ", ")
-						}
-
-						return s.prefix[:len(s.prefix)-4] + "(" + name + ") › ", true
-					}
-
-					return "", false
-				}),
-				prompt.OptionPrefixTextColor(prompt.Cyan),
-				prompt.OptionInputTextColor(prompt.DefaultColor),
-				prompt.OptionCompletionWordSeparator(completer.FilePathCompletionSeparator),
-				prompt.OptionHistoryIgnoreDuplicates(),
-				prompt.OptionSetExitCheckerOnInput(func(in string, breakline bool) bool {
-					return breakline && in == "exit"
-				}),
-				prompt.OptionHistory(histories),
-				// macos alt+left fix
-				prompt.OptionAddASCIICodeBind(prompt.ASCIICodeBind{
-					ASCIICode: []byte{0x1b, 0x62},
-					Fn:        prompt.GoLeftWord,
-				}),
-				// macos alt+right fix
-				prompt.OptionAddASCIICodeBind(prompt.ASCIICodeBind{
-					ASCIICode: []byte{0x1b, 0x66},
-					Fn:        prompt.GoRightWord,
-				}),
-			},
-			s.promptOptions...,
-		)...,
+		append(baseOptions, s.promptOptions...)...,
 	)
 
 	if err := s.flair(s.title); err != nil {
@@ -312,6 +333,10 @@ func (s *Prompt) alias(input string, aliases map[string]string) string {
 }
 
 func (s *Prompt) execute(input string) {
+	for strings.HasPrefix(input, historySearchPrefix) {
+		input = strings.TrimPrefix(input, historySearchPrefix)
+	}
+
 	input = strings.TrimSpace(input)
 	if input == "" {
 		return
@@ -360,6 +385,12 @@ func (s *Prompt) complete(d prompt.Document) []prompt.Suggest {
 	input := d.TextBeforeCursor()
 	if input == "" {
 		return nil
+	}
+
+	if s.historySearch {
+		if rest, ok := strings.CutPrefix(input, historySearchPrefix); ok {
+			return s.completeHistory(rest)
+		}
 	}
 
 	input = s.alias(input, s.aliases)
@@ -415,6 +446,55 @@ func (s *Prompt) complete(d prompt.Document) []prompt.Suggest {
 	}
 
 	return nil
+}
+
+func (s *Prompt) activateHistorySearch(buf *prompt.Buffer) {
+	if strings.HasPrefix(buf.Text(), historySearchPrefix) {
+		return
+	}
+
+	if n := len([]rune(buf.Text())); n > 0 {
+		buf.DeleteBeforeCursor(n)
+	}
+
+	buf.InsertText(historySearchPrefix, false, true)
+}
+
+func (s *Prompt) completeHistory(query string) []prompt.Suggest {
+	h, err := s.history.Load(context.Background())
+	if err != nil {
+		return nil
+	}
+
+	if len(h) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(h))
+	suggests := make([]prompt.Suggest, 0, historySearchMaxResults)
+
+	for _, line := range slices.Backward(h) {
+		if line == "" {
+			continue
+		}
+
+		if _, dup := seen[line]; dup {
+			continue
+		}
+
+		if query != "" && !fuzzy.MatchFold(query, line) {
+			continue
+		}
+
+		seen[line] = struct{}{}
+		suggests = append(suggests, prompt.Suggest{Text: line, Description: ""})
+
+		if len(suggests) >= historySearchMaxResults {
+			break
+		}
+	}
+
+	return suggests
 }
 
 // context returns and watches over a new context

--- a/posh.schema.json
+++ b/posh.schema.json
@@ -52,6 +52,9 @@
         "history": {
           "$ref": "#/$defs/PromptHistory"
         },
+        "historySearch": {
+          "type": "boolean"
+        },
         "aliases": {
           "additionalProperties": {
             "type": "string"


### PR DESCRIPTION
### Description

Add opt-in CTRL+R fuzzy history search to the interactive prompt via a new `WithHistorySearch` option.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [x] 🔧 Build/CI

### Changes

- feat: add history search
  - `pkg/prompt`: new `WithHistorySearch` option wires `CTRL+R` to inject a sentinel prefix; `complete()` returns fuzzy-matched history (via `lithammer/fuzzysearch`); `execute()` strips the sentinel before dispatch
  - `pkg/config/prompt.go` + `posh.schema.json`: config surface for the new option
  - `embed/scaffold/init/$.posh.yaml` + `plugin.go.gotext`: scaffold wires the option through
  - `go.mod`/`go.sum`: promote `lithammer/fuzzysearch` from indirect to direct

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.