### PR TITLE
feat: add command provider

### DIFF
--- a/pkg/exec/commandprovider.go
+++ b/pkg/exec/commandprovider.go
@@ -1,0 +1,7 @@
+package exec
+
+import (
+	"context"
+)
+
+type CommandProvider func(ctx context.Context, args ...string) *Command


### PR DESCRIPTION
### Description

Add `CommandProvider` function type to `pkg/exec` — a factory signature that takes a context plus args and returns an `*exec.Command`. Lets consumers inject command construction into call sites that need lazy/contextual command building instead of a prebuilt `*Command`.

### Type of Change

- [x] ✨ New feature

### Changes

- Add `pkg/exec/commandprovider.go` defining `type CommandProvider func(ctx context.Context, args ...string) *Command`.

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.