### PR TITLE
feat: add ai tooling

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"context"
+
+	intcmd "github.com/foomo/posh/internal/cmd"
+	intconfig "github.com/foomo/posh/internal/config"
+	"github.com/foomo/posh/pkg/agent"
+	"github.com/foomo/posh/pkg/plugin"
+	"github.com/spf13/cobra"
+)
+
+// NewAgent represents the agent command group: tooling for AI coding agents
+// driving posh, as opposed to the per-invocation `--agent` root flag.
+func NewAgent(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "agent",
+		Short: "Tooling for AI coding agents driving this project's posh shell",
+	}
+
+	newAgentCatalog(cmd)
+	newAgentSkill(cmd)
+
+	root.AddCommand(cmd)
+}
+
+// newAgentCatalog represents the `agent catalog` command
+func newAgentCatalog(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:           "catalog",
+		Short:         "Print this project's command catalog as JSON",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			l := intcmd.NewLogger()
+			return intconfig.Load(l)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			commands, err := loadCatalog(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			return agent.Encode(plugin.NewCatalog(commands))
+		},
+	}
+
+	root.AddCommand(cmd)
+}
+
+// newAgentSkill represents the `agent skill` command group
+func newAgentSkill(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "skill",
+		Short: "Generate a Claude Code skill describing this project's posh shell",
+	}
+
+	install := &cobra.Command{
+		Use:           "install [path]",
+		Short:         "Write the generated skill to disk",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			l := intcmd.NewLogger()
+			return intconfig.Load(l)
+		},
+		RunE: runAgentSkillInstall,
+	}
+
+	// get renders the same skill install would write, but to stdout - so an
+	// agent can read it without touching the working tree.
+	get := &cobra.Command{
+		Use:           "get",
+		Short:         "Print the generated skill to stdout",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PreRunE:       install.PreRunE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			meta, commands, err := loadSkill(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			_, err = cmd.OutOrStdout().Write([]byte(plugin.RenderSkill(meta, commands)))
+
+			return err
+		},
+	}
+
+	uninstall := &cobra.Command{
+		Use:           "uninstall [path]",
+		Short:         "Remove the generated skill from disk",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var path string
+			if len(args) > 0 {
+				path = args[0]
+			}
+
+			return plugin.RemoveSkill(path)
+		},
+	}
+
+	// update is install by another name: both (re-)generate the skill from
+	// this project's live command catalog, so re-running after adding or
+	// changing providers always produces an up-to-date file.
+	update := &cobra.Command{
+		Use:           "update [path]",
+		Short:         "Regenerate the skill file after this project's commands changed",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PreRunE:       install.PreRunE,
+		RunE:          runAgentSkillInstall,
+	}
+
+	cmd.AddCommand(get, install, update, uninstall)
+	root.AddCommand(cmd)
+}
+
+func runAgentSkillInstall(cmd *cobra.Command, args []string) error {
+	meta, commands, err := loadSkill(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	var path string
+	if len(args) > 0 {
+		path = args[0]
+	}
+
+	return plugin.WriteSkill(path, meta, commands)
+}
+
+// loadCatalog resolves this project's plugin and asks it for the command
+// catalog.
+//
+// Only the resolution stays here: it goes through pluginProvider - package
+// state set by Init - and internal/cmd, neither of which pkg/ may import.
+func loadCatalog(ctx context.Context) ([]plugin.CommandInfo, error) {
+	plg, err := pluginProvider(intcmd.NewLogger())
+	if err != nil {
+		return nil, err
+	}
+
+	return plugin.List(ctx, plg)
+}
+
+// loadSkill resolves this project's plugin and asks it for everything the
+// generated skill needs: the frontmatter and the command catalog with per
+// command prose.
+//
+// It is kept apart from loadCatalog so `agent catalog` keeps emitting the
+// unchanged catalog shape.
+func loadSkill(ctx context.Context) (plugin.SkillMetadata, []plugin.SkillCommand, error) {
+	plg, err := pluginProvider(intcmd.NewLogger())
+	if err != nil {
+		return plugin.SkillMetadata{}, nil, err
+	}
+
+	commands, err := plugin.ListSkill(ctx, plg)
+	if err != nil {
+		return plugin.SkillMetadata{}, nil, err
+	}
+
+	return plugin.SkillMetadataOf(ctx, plg), commands, nil
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -11,6 +11,7 @@ import (
 	cowsay "github.com/Code-Hex/Neo-cowsay/v2"
 	"github.com/foomo/posh/internal/cmd"
 	intenv "github.com/foomo/posh/internal/env"
+	"github.com/foomo/posh/pkg/agent"
 	"github.com/foomo/posh/pkg/plugin"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -23,6 +24,7 @@ func Init(provider plugin.Provider) {
 	NewVersion(rootCmd)
 
 	if provider != nil {
+		NewAgent(rootCmd)
 		NewBrew(rootCmd)
 		NewExecute(rootCmd)
 		NewPrompt(rootCmd)
@@ -50,7 +52,13 @@ func Execute() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	// Guarded here rather than at each call site, so both the panic and the
+	// error path below are covered: ASCII art is noise in a JSON message field.
 	say := func(msg string) string {
+		if agent.IsAgentMode() {
+			return msg
+		}
+
 		if say, err := cowsay.Say(msg, cowsay.BallonWidth(80)); err == nil {
 			msg = say
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/foomo/ownbrew/pkg/util"
 	intcmd "github.com/foomo/posh/internal/cmd"
 	intconfig "github.com/foomo/posh/internal/config"
+	"github.com/foomo/posh/pkg/agent"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
@@ -27,14 +28,29 @@ func NewConfig(root *cobra.Command) {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out, err := yaml.Marshal(viper.AllSettings())
-			if err != nil {
-				return err
-			}
+			// The settings map is already what an agent wants, so it is encoded
+			// as-is rather than through a payload struct: the config shape is
+			// open ended and defined by each project, not by posh.
+			return agent.Render(
+				func() any { return viper.AllSettings() },
+				func() error {
+					out, err := yaml.Marshal(viper.AllSettings())
+					if err != nil {
+						return err
+					}
 
-			fmt.Println(util.Highlight(string(out), "yaml"))
+					// Highlight colors via chroma, which --no-color does not
+					// reach: the flag only toggles a pterm global, and this
+					// command writes to stdout rather than through the logger.
+					if viper.GetBool("no-color") {
+						fmt.Println(string(out))
+					} else {
+						fmt.Println(util.Highlight(string(out), "yaml"))
+					}
 
-			return nil
+					return nil
+				},
+			)
 		},
 	}
 

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,96 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/foomo/posh/cmd"
+	"github.com/foomo/posh/pkg/agent"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// configCmd registers the config command on a throwaway root and returns it.
+//
+// The command is driven through RunE directly rather than Execute: PreRunE
+// loads .posh.yaml from the working directory, which is the config loader's
+// behavior to test, not this command's output.
+func configCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+
+	root := &cobra.Command{Use: "posh"}
+	cmd.NewConfig(root)
+
+	for _, c := range root.Commands() {
+		if c.Name() == "config" {
+			return c
+		}
+	}
+
+	t.Fatal("config command not registered")
+
+	return nil
+}
+
+func TestConfig_AgentMode(t *testing.T) {
+	defer agent.SetDetected(true)()
+
+	viper.Set("some-key", "some-value")
+	defer viper.Set("some-key", nil)
+
+	c := configCmd(t)
+
+	var err error
+
+	out := captureStdout(t, func() { err = c.RunE(c, nil) })
+	require.NoError(t, err)
+
+	assert.NotContains(t, out, "\033", "agent output must carry no ANSI escapes")
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &got), "agent output must be one JSON value")
+	assert.Equal(t, "some-value", got["some-key"])
+}
+
+// TestConfig_NoColor covers the --no-color flag reaching this command: it
+// highlights via chroma, which the pterm global the flag otherwise toggles does
+// not affect.
+func TestConfig_NoColor(t *testing.T) {
+	defer agent.SetDetected(false)()
+
+	viper.Set("no-color", true)
+	defer viper.Set("no-color", false)
+
+	viper.Set("some-key", "some-value")
+	defer viper.Set("some-key", nil)
+
+	c := configCmd(t)
+
+	var err error
+
+	out := captureStdout(t, func() { err = c.RunE(c, nil) })
+	require.NoError(t, err)
+
+	assert.NotContains(t, out, "\033")
+	assert.Contains(t, out, "some-key: some-value")
+}
+
+// TestConfig_Color is the counterpart: without the flag the human path still
+// highlights, so the no-color assertion above is testing something.
+func TestConfig_Color(t *testing.T) {
+	defer agent.SetDetected(false)()
+
+	viper.Set("some-key", "some-value")
+	defer viper.Set("some-key", nil)
+
+	c := configCmd(t)
+
+	var err error
+
+	out := captureStdout(t, func() { err = c.RunE(c, nil) })
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "\033", "human output is syntax highlighted")
+}

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -1,7 +1,7 @@
 // Command docgen generates Markdown documentation for every cobra command
 // shipped by posh — both the binary-only commands (init, config, version) and
-// the downstream-only commands that require a Plugin (prompt, execute, brew,
-// require).
+// the downstream-only commands that require a Plugin (agent, prompt, execute,
+// brew, require).
 //
 // Output is one Markdown file per command, suitable for VitePress. The file
 // header is rewritten so each page has a `# posh <subcommand>` title and a
@@ -127,6 +127,7 @@ func buildFullTree() *cobra.Command {
 	cmd.NewInit(root)
 	cmd.NewConfig(root)
 	cmd.NewVersion(root)
+	cmd.NewAgent(root)
 	cmd.NewBrew(root)
 	cmd.NewExecute(root)
 	cmd.NewPrompt(root)

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	intcmd "github.com/foomo/posh/internal/cmd"
 	intconfig "github.com/foomo/posh/internal/config"
+	"github.com/foomo/posh/pkg/agent"
 	"github.com/foomo/posh/pkg/plugin"
+	"github.com/foomo/posh/pkg/readline"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +29,14 @@ func NewExecute(root *cobra.Command) {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// DisableFlagParsing means cobra never populates this command's
+			// flags, so posh's own are scanned off the front by hand.
+			args = readline.ExtractFlags(args, map[string]func(){
+				agent.Flag: func() { agent.SetFlag(true) },
+			})
+
+			// Logger must be built after ExtractFlags, which may have set
+			// agent mode via a leading --agent.
 			l := intcmd.NewLogger()
 
 			if len(args) == 0 {

--- a/cmd/helper_test.go
+++ b/cmd/helper_test.go
@@ -1,0 +1,36 @@
+package cmd_test
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// captureStdout swaps the process stdout for a pipe. The JSON encoder writes to
+// the real descriptor, so a writer-only capture would miss it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	orig := os.Stdout
+	os.Stdout = w
+
+	done := make(chan string, 1)
+
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+
+	return <-done
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	intconfig "github.com/foomo/posh/internal/config"
+	"github.com/foomo/posh/pkg/agent"
 	"github.com/foomo/posh/pkg/plugin"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -18,6 +19,7 @@ func NewRoot() *cobra.Command {
 		Use:   "posh",
 		Short: "Project Oriented Shell (posh)",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			agent.SetFlag(viper.GetBool("agent"))
 			return intconfig.Dotenv()
 		},
 	}
@@ -27,6 +29,9 @@ func NewRoot() *cobra.Command {
 
 	cmd.PersistentFlags().String("level", "info", "set log level (default: info)")
 	_ = viper.BindPFlag("level", cmd.PersistentFlags().Lookup("level"))
+
+	cmd.PersistentFlags().Bool("agent", false, "force agent mode: JSON output, no interactive prompts (default: auto-detected)")
+	_ = viper.BindPFlag("agent", cmd.PersistentFlags().Lookup("agent"))
 
 	return cmd
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,6 +6,8 @@ import (
 
 	intcmd "github.com/foomo/posh/internal/cmd"
 	intversion "github.com/foomo/posh/internal/version"
+	"github.com/foomo/posh/pkg/agent"
+	"github.com/foomo/posh/pkg/command"
 	"github.com/foomo/posh/pkg/log"
 	"github.com/spf13/cobra"
 )
@@ -13,10 +15,12 @@ import (
 // NewVersion represents the version command
 func NewVersion(root *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "Print the version",
-		Long:  `If unsure which version of the CLI you are using, you can use this command to print the version of the CLI.`,
-		Run: func(cmd *cobra.Command, args []string) {
+		Use:           "version",
+		Short:         "Print the version",
+		Long:          `If unsure which version of the CLI you are using, you can use this command to print the version of the CLI.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
 			l := intcmd.NewLogger()
 
 			buildTime := intversion.BuildTimestamp
@@ -24,11 +28,30 @@ func NewVersion(root *cobra.Command) {
 				buildTime = time.Unix(value, 0).String()
 			}
 
-			if l.IsLevel(log.LevelDebug) {
-				l.Printf("Version: %s\nCommit: %s\nBuildTime: %s", intversion.Version, intversion.CommitHash, buildTime)
-			} else {
-				l.Printf("%s", intversion.Version)
-			}
+			// The debug gate governs both forms, so the agent payload carries
+			// exactly the fields the human output prints.
+			debug := l.IsLevel(log.LevelDebug)
+
+			return agent.Render(
+				func() any {
+					ret := command.Version{Version: intversion.Version}
+					if debug {
+						ret.Commit = intversion.CommitHash
+						ret.BuildTime = buildTime
+					}
+
+					return ret
+				},
+				func() error {
+					if debug {
+						l.Printf("Version: %s\nCommit: %s\nBuildTime: %s", intversion.Version, intversion.CommitHash, buildTime)
+					} else {
+						l.Printf("%s", intversion.Version)
+					}
+
+					return nil
+				},
+			)
 		},
 	}
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,56 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/foomo/posh/cmd"
+	intversion "github.com/foomo/posh/internal/version"
+	"github.com/foomo/posh/pkg/agent"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func versionCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+
+	root := &cobra.Command{Use: "posh"}
+	cmd.NewVersion(root)
+
+	for _, c := range root.Commands() {
+		if c.Name() == "version" {
+			return c
+		}
+	}
+
+	t.Fatal("version command not registered")
+
+	return nil
+}
+
+// TestVersion_AgentMode covers the regression this change is about: the version
+// used to be delivered as a pkg/log.AgentJSON entry, so the result carried the
+// "type" field that is supposed to mark an interleaved log line rather than a
+// result value.
+func TestVersion_AgentMode(t *testing.T) {
+	defer agent.SetDetected(true)()
+
+	c := versionCmd(t)
+
+	var err error
+
+	out := captureStdout(t, func() { err = c.RunE(c, nil) })
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &got), "agent output must be one JSON value")
+
+	assert.Equal(t, intversion.Version, got["version"])
+	assert.NotContains(t, got, "type", "a result value must not carry the log discriminator")
+	assert.NotContains(t, got, "message")
+
+	// Commit and build time are debug-level only, and the default level is info.
+	assert.NotContains(t, got, "commit")
+	assert.NotContains(t, got, "build_time")
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -37,6 +37,7 @@ export default defineConfig({
 				items: [
 					{text: 'The Interactive Prompt', link: '/usage/prompt'},
 					{text: 'Built-in Commands', link: '/usage/builtins'},
+					{text: 'AI Agents', link: '/usage/agents'},
 					{text: 'Configuration', link: '/usage/configuration'},
 					{text: 'Project Layout', link: '/usage/layout'},
 				],
@@ -50,6 +51,7 @@ export default defineConfig({
 					{text: 'posh init', link: '/reference/cli/posh_init'},
 					{text: 'posh config', link: '/reference/cli/posh_config'},
 					{text: 'posh version', link: '/reference/cli/posh_version'},
+					{text: 'posh agent', link: '/reference/cli/posh_agent'},
 					{text: 'posh prompt', link: '/reference/cli/posh_prompt'},
 					{text: 'posh execute', link: '/reference/cli/posh_execute'},
 					{text: 'posh require', link: '/reference/cli/posh_require'},

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -87,8 +87,12 @@ The base interface is intentionally minimal. Layer in extra capabilities by also
 | `FlagCompleter` | Completion when typing `--something` |
 | `AdditionalArgsCompleter` | Anything after `--` |
 | `PassThroughFlagsCompleter` | Flags passed through to a wrapped tool |
+| `Describer` | `posh agent catalog`, to describe the command's structure |
+| `Skiller` | `posh agent skill`, to contribute extra markdown |
 
 The prompt uses Go type assertions to detect what each command supports. There is no super-interface to implement — pick what you need. See [Writing Commands](/plugin/writing-commands) for examples.
+
+The same rule holds one level up: `Plugin` stays at four methods, and agent-facing capabilities are opt-in interfaces beside it. See [AI Agents](/usage/agents).
 
 ## The prompt loop
 

--- a/docs/plugin/overview.md
+++ b/docs/plugin/overview.md
@@ -25,6 +25,19 @@ Each method backs one cobra subcommand on `bin/posh`:
 
 The framework wires each cobra command, parses flags, loads config, and hands you a typed struct. Your job is to wire the implementation — usually **just composition** of helpers from `pkg/...`.
 
+### Optional extensions
+
+Like commands, plugins gain capabilities by *also* implementing an optional interface. Each is detected by type assertion, so leaving one out is never a breaking change:
+
+| Interface | Method | Backs |
+| --- | --- | --- |
+| `Completer` | `Complete(ctx, args, toComplete) []string` | Shell completion for `posh execute` |
+| `Lister` | `List(ctx) []CommandInfo` | [`posh agent catalog`](/usage/agents#posh-agent-catalog) |
+| `SkillLister` | `ListSkill(ctx) []SkillCommand` | [`posh agent skill`](/usage/agents#posh-agent-skill) |
+| `SkillMetadataer` | `SkillMetadata(ctx) SkillMetadata` | The generated skill's frontmatter |
+
+The scaffolded plugin implements the last three out of the box — see [AI Agents](/usage/agents) for what they produce.
+
 ## The scaffolded plugin
 
 `posh init` writes `.posh/internal/plugin.go`, a near-canonical implementation:
@@ -60,7 +73,7 @@ The constructor:
 2. Registers always-on built-ins (`exit`, `help`)
 3. Registers your custom commands
 
-`Prompt`, `Execute`, `Brew`, `Require` are all implemented in the same file — about 70 LOC total. Read it once, then come back here to extend.
+`Prompt`, `Execute`, `Brew`, `Require` are all implemented in the same file, along with the agent-facing `List`, `ListSkill` and `SkillMetadata`. Read it once, then come back here to extend.
 
 ### `Prompt`
 

--- a/docs/plugin/writing-commands.md
+++ b/docs/plugin/writing-commands.md
@@ -110,6 +110,53 @@ func (c *Server) Shutdown(ctx context.Context) error {
 
 Called when the prompt loop exits. Every `Shutdowner` runs in parallel with a 3-second deadline. If you hold long-running resources (HTTP servers, database connections, watchers), implement this.
 
+### `Describer` — agent catalog
+
+```go
+func (c *Hello) Describe(ctx context.Context) command.CommandInfo {
+    return command.CommandInfo{
+        FullPath:    "hello",
+        Description: "say hello",
+        Arguments: []command.ArgInfo{
+            {Name: "name", Description: "who to greet", Optional: true},
+        },
+    }
+}
+```
+
+Backs [`posh agent catalog`](/usage/agents#posh-agent-catalog), which gives an AI coding agent a machine-readable
+answer to "what can I run" instead of making it parse help text. Commands that don't implement it are still listed —
+just as leaves with only a name and description.
+
+Tree-based commands delegate like every other tree method:
+
+```go
+func (c *Kube) Describe(ctx context.Context) command.CommandInfo {
+    return c.tree.Describe(ctx)
+}
+```
+
+The contract is `CommandInfo`, not `*tree.Node` — you stay free to change how you model your command's structure, or to
+build the info by hand, without breaking the catalog.
+
+### `Skiller` — agent skill prose
+
+```go
+func (c *Hello) Skill(ctx context.Context) string {
+    return `#### When to use
+
+Prefer this over ` + "`echo`" + ` — it reads the greeting format from .posh.yaml.
+`
+}
+```
+
+Extra markdown for [`posh agent skill`](/usage/agents#posh-agent-skill), appended verbatim under this command's `###`
+heading — extended instructions, worked config examples, links. Use heading level 4 (`####`) or deeper; level 3 is the
+command heading itself.
+
+It's free-form text rather than a struct because what's worth telling an agent varies per command, and the destination
+is markdown either way. Top-level commands only — nested subcommands keep their compact indented listing.
+
 ### Completion
 
 Three flavours, picked by the parser's mode:

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -10,7 +10,7 @@ This section is auto-generated from the cobra command tree by `cmd/docgen`. Rege
 make docs.cli
 ```
 
-The output is committed to git, so the docs site builds without Go installed. CI verifies the generated tree matches the current command definitions.
+The output is committed to git, so the docs site builds without Go installed. Re-run `make docs.cli` and commit the result whenever you add, remove or reflag a cobra command.
 
 ## Two flavours
 
@@ -19,12 +19,13 @@ The output is committed to git, so the docs site builds without Go installed. CI
 | [`posh init`](./posh_init) | ✅ | — |
 | [`posh config`](./posh_config) | ✅ | ✅ |
 | [`posh version`](./posh_version) | ✅ | ✅ |
+| [`posh agent`](./posh_agent) | — | ✅ |
 | [`posh prompt`](./posh_prompt) | — | ✅ |
 | [`posh execute`](./posh_execute) | — | ✅ |
 | [`posh require`](./posh_require) | — | ✅ |
 | [`posh brew`](./posh_brew) | — | ✅ |
 
-The split exists because `prompt`, `execute`, `require` and `brew` delegate to the [`Plugin`](/plugin/overview) compiled into the project binary. The global `posh` has no plugin to delegate to.
+The split exists because `agent`, `prompt`, `execute`, `require` and `brew` delegate to the [`Plugin`](/plugin/overview) compiled into the project binary. The global `posh` has no plugin to delegate to.
 
 ## All commands
 
@@ -32,6 +33,9 @@ The split exists because `prompt`, `execute`, `require` and `brew` delegate to t
 - [posh init](./posh_init)
 - [posh config](./posh_config)
 - [posh version](./posh_version)
+- [posh agent](./posh_agent)
+  - [posh agent catalog](./posh_agent_catalog)
+  - [posh agent skill](./posh_agent_skill)
 - [posh prompt](./posh_prompt)
 - [posh execute](./posh_execute)
 - [posh require](./posh_require)

--- a/docs/reference/cli/posh.md
+++ b/docs/reference/cli/posh.md
@@ -9,6 +9,7 @@ Project Oriented Shell (posh)
 ### Options
 
 ```
+      --agent          force agent mode: JSON output, no interactive prompts (default: auto-detected)
   -h, --help           help for posh
       --level string   set log level (default: info) (default "info")
       --no-color       disabled colors (default: false)
@@ -16,6 +17,7 @@ Project Oriented Shell (posh)
 
 ### SEE ALSO
 
+* [posh agent](posh_agent.md)	 - Tooling for AI coding agents driving this project's posh shell
 * [posh brew](posh_brew.md)	 - Check and install required packages.
 * [posh config](posh_config.md)	 - Print loaded configuration
 * [posh execute](posh_execute.md)	 - Execute a single Project Oriented Shell command

--- a/docs/reference/cli/posh_agent.md
+++ b/docs/reference/cli/posh_agent.md
@@ -1,21 +1,15 @@
 ---
-title: posh brew
+title: posh agent
 ---
 
-## posh brew
+## posh agent
 
-Check and install required packages.
-
-```
-posh brew [flags]
-```
+Tooling for AI coding agents driving this project's posh shell
 
 ### Options
 
 ```
-      --dry            print out the taps that will be installed
-  -h, --help           help for brew
-      --tags strings   filter by tags (e.g. ci,-test)
+  -h, --help   help for agent
 ```
 
 ### Options inherited from parent commands
@@ -29,4 +23,6 @@ posh brew [flags]
 ### SEE ALSO
 
 * [posh](posh.md)	 - Project Oriented Shell (posh)
+* [posh agent catalog](posh_agent_catalog.md)	 - Print this project's command catalog as JSON
+* [posh agent skill](posh_agent_skill.md)	 - Generate a Claude Code skill describing this project's posh shell
 

--- a/docs/reference/cli/posh_agent_catalog.md
+++ b/docs/reference/cli/posh_agent_catalog.md
@@ -1,21 +1,19 @@
 ---
-title: posh brew
+title: posh agent catalog
 ---
 
-## posh brew
+## posh agent catalog
 
-Check and install required packages.
+Print this project's command catalog as JSON
 
 ```
-posh brew [flags]
+posh agent catalog [flags]
 ```
 
 ### Options
 
 ```
-      --dry            print out the taps that will be installed
-  -h, --help           help for brew
-      --tags strings   filter by tags (e.g. ci,-test)
+  -h, --help   help for catalog
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ posh brew [flags]
 
 ### SEE ALSO
 
-* [posh](posh.md)	 - Project Oriented Shell (posh)
+* [posh agent](posh_agent.md)	 - Tooling for AI coding agents driving this project's posh shell
 

--- a/docs/reference/cli/posh_agent_skill.md
+++ b/docs/reference/cli/posh_agent_skill.md
@@ -1,0 +1,30 @@
+---
+title: posh agent skill
+---
+
+## posh agent skill
+
+Generate a Claude Code skill describing this project's posh shell
+
+### Options
+
+```
+  -h, --help   help for skill
+```
+
+### Options inherited from parent commands
+
+```
+      --agent          force agent mode: JSON output, no interactive prompts (default: auto-detected)
+      --level string   set log level (default: info) (default "info")
+      --no-color       disabled colors (default: false)
+```
+
+### SEE ALSO
+
+* [posh agent](posh_agent.md)	 - Tooling for AI coding agents driving this project's posh shell
+* [posh agent skill get](posh_agent_skill_get.md)	 - Print the generated skill to stdout
+* [posh agent skill install](posh_agent_skill_install.md)	 - Write the generated skill to disk
+* [posh agent skill uninstall](posh_agent_skill_uninstall.md)	 - Remove the generated skill from disk
+* [posh agent skill update](posh_agent_skill_update.md)	 - Regenerate the skill file after this project's commands changed
+

--- a/docs/reference/cli/posh_agent_skill_get.md
+++ b/docs/reference/cli/posh_agent_skill_get.md
@@ -1,21 +1,19 @@
 ---
-title: posh brew
+title: posh agent skill get
 ---
 
-## posh brew
+## posh agent skill get
 
-Check and install required packages.
+Print the generated skill to stdout
 
 ```
-posh brew [flags]
+posh agent skill get [flags]
 ```
 
 ### Options
 
 ```
-      --dry            print out the taps that will be installed
-  -h, --help           help for brew
-      --tags strings   filter by tags (e.g. ci,-test)
+  -h, --help   help for get
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ posh brew [flags]
 
 ### SEE ALSO
 
-* [posh](posh.md)	 - Project Oriented Shell (posh)
+* [posh agent skill](posh_agent_skill.md)	 - Generate a Claude Code skill describing this project's posh shell
 

--- a/docs/reference/cli/posh_agent_skill_install.md
+++ b/docs/reference/cli/posh_agent_skill_install.md
@@ -1,21 +1,19 @@
 ---
-title: posh brew
+title: posh agent skill install
 ---
 
-## posh brew
+## posh agent skill install
 
-Check and install required packages.
+Write the generated skill to disk
 
 ```
-posh brew [flags]
+posh agent skill install [path] [flags]
 ```
 
 ### Options
 
 ```
-      --dry            print out the taps that will be installed
-  -h, --help           help for brew
-      --tags strings   filter by tags (e.g. ci,-test)
+  -h, --help   help for install
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ posh brew [flags]
 
 ### SEE ALSO
 
-* [posh](posh.md)	 - Project Oriented Shell (posh)
+* [posh agent skill](posh_agent_skill.md)	 - Generate a Claude Code skill describing this project's posh shell
 

--- a/docs/reference/cli/posh_agent_skill_uninstall.md
+++ b/docs/reference/cli/posh_agent_skill_uninstall.md
@@ -1,21 +1,19 @@
 ---
-title: posh brew
+title: posh agent skill uninstall
 ---
 
-## posh brew
+## posh agent skill uninstall
 
-Check and install required packages.
+Remove the generated skill from disk
 
 ```
-posh brew [flags]
+posh agent skill uninstall [path] [flags]
 ```
 
 ### Options
 
 ```
-      --dry            print out the taps that will be installed
-  -h, --help           help for brew
-      --tags strings   filter by tags (e.g. ci,-test)
+  -h, --help   help for uninstall
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ posh brew [flags]
 
 ### SEE ALSO
 
-* [posh](posh.md)	 - Project Oriented Shell (posh)
+* [posh agent skill](posh_agent_skill.md)	 - Generate a Claude Code skill describing this project's posh shell
 

--- a/docs/reference/cli/posh_agent_skill_update.md
+++ b/docs/reference/cli/posh_agent_skill_update.md
@@ -1,21 +1,19 @@
 ---
-title: posh brew
+title: posh agent skill update
 ---
 
-## posh brew
+## posh agent skill update
 
-Check and install required packages.
+Regenerate the skill file after this project's commands changed
 
 ```
-posh brew [flags]
+posh agent skill update [path] [flags]
 ```
 
 ### Options
 
 ```
-      --dry            print out the taps that will be installed
-  -h, --help           help for brew
-      --tags strings   filter by tags (e.g. ci,-test)
+  -h, --help   help for update
 ```
 
 ### Options inherited from parent commands
@@ -28,5 +26,5 @@ posh brew [flags]
 
 ### SEE ALSO
 
-* [posh](posh.md)	 - Project Oriented Shell (posh)
+* [posh agent skill](posh_agent_skill.md)	 - Generate a Claude Code skill describing this project's posh shell
 

--- a/docs/reference/cli/posh_config.md
+++ b/docs/reference/cli/posh_config.md
@@ -19,6 +19,7 @@ posh config [flags]
 ### Options inherited from parent commands
 
 ```
+      --agent          force agent mode: JSON output, no interactive prompts (default: auto-detected)
       --level string   set log level (default: info) (default "info")
       --no-color       disabled colors (default: false)
 ```

--- a/docs/reference/cli/posh_execute.md
+++ b/docs/reference/cli/posh_execute.md
@@ -19,6 +19,7 @@ posh execute [flags]
 ### Options inherited from parent commands
 
 ```
+      --agent          force agent mode: JSON output, no interactive prompts (default: auto-detected)
       --level string   set log level (default: info) (default "info")
       --no-color       disabled colors (default: false)
 ```

--- a/docs/reference/cli/posh_init.md
+++ b/docs/reference/cli/posh_init.md
@@ -27,6 +27,7 @@ posh init [flags]
 ### Options inherited from parent commands
 
 ```
+      --agent          force agent mode: JSON output, no interactive prompts (default: auto-detected)
       --level string   set log level (default: info) (default "info")
       --no-color       disabled colors (default: false)
 ```

--- a/docs/reference/cli/posh_prompt.md
+++ b/docs/reference/cli/posh_prompt.md
@@ -19,6 +19,7 @@ posh prompt [flags]
 ### Options inherited from parent commands
 
 ```
+      --agent          force agent mode: JSON output, no interactive prompts (default: auto-detected)
       --level string   set log level (default: info) (default "info")
       --no-color       disabled colors (default: false)
 ```

--- a/docs/reference/cli/posh_require.md
+++ b/docs/reference/cli/posh_require.md
@@ -19,6 +19,7 @@ posh require [flags]
 ### Options inherited from parent commands
 
 ```
+      --agent          force agent mode: JSON output, no interactive prompts (default: auto-detected)
       --level string   set log level (default: info) (default "info")
       --no-color       disabled colors (default: false)
 ```

--- a/docs/reference/cli/posh_version.md
+++ b/docs/reference/cli/posh_version.md
@@ -23,6 +23,7 @@ posh version [flags]
 ### Options inherited from parent commands
 
 ```
+      --agent          force agent mode: JSON output, no interactive prompts (default: auto-detected)
       --level string   set log level (default: info) (default "info")
       --no-color       disabled colors (default: false)
 ```

--- a/docs/usage/builtins.md
+++ b/docs/usage/builtins.md
@@ -94,3 +94,12 @@ These aren't always-on built-ins, but the package ships a few more constructors 
 | `command.NewCheck(...)` | Wraps a `check.Checker` as a callable command          |
 
 See the godoc for current signatures: <https://pkg.go.dev/github.com/foomo/posh/pkg/command>.
+
+## Agent-facing output
+
+Every built-in above describes itself to [`posh agent catalog`](/usage/agents#posh-agent-catalog) and contributes prose
+to the generated skill. `cache` and `env` additionally print JSON instead of tables when
+[agent mode](/usage/agents#agent-mode) is active — so the same command serves a human at the prompt and an AI agent in
+CI. Your own commands opt in the same way, via
+[`Describer`](/plugin/writing-commands#describer-agent-catalog) and
+[`Skiller`](/plugin/writing-commands#skiller-agent-skill-prose).

--- a/embed/scaffold/init/$.posh/internal/command/welcome.go.gotext
+++ b/embed/scaffold/init/$.posh/internal/command/welcome.go.gotext
@@ -71,6 +71,24 @@ func (c *Welcome) Execute(ctx context.Context, r *readline.Readline) error {
 	return nil
 }
 
+// Skill implements the optional command.Skiller interface: markdown appended
+// under this command's heading in the generated SKILL.md, for anything an AI
+// coding agent cannot infer from the command's structure alone.
+//
+// Use it for what is genuinely non-obvious - side effects, prerequisites, which
+// of several similar commands to reach for, why an empty result is normal. The
+// name, description, arguments and flags are already in the catalog, so
+// repeating them here only costs the agent tokens. Delete this method if a
+// command has nothing to add. Start headings at level 4 (####): level 3 is the
+// command's own.
+func (c *Welcome) Skill(ctx context.Context) string {
+	return `#### Notes
+
+Prints the welcome message configured under ` + "`welcome.message`" + ` in
+` + "`.posh.yaml`" + `. It has no side effects and is a good first command to
+run to confirm the shell is wired up correctly.`
+}
+
 func (c *Welcome) Help(ctx context.Context, r *readline.Readline) string {
 	return `Print a welcome message
 

--- a/embed/scaffold/init/$.posh/internal/plugin.go.gotext
+++ b/embed/scaffold/init/$.posh/internal/plugin.go.gotext
@@ -91,20 +91,61 @@ func (p *Plugin) Execute(ctx context.Context, args []string) error {
 		return err
 	}
 
-	if cmd := p.commands.Get(r.Cmd()); cmd == nil {
+	cmd := p.commands.Get(r.Cmd())
+	if cmd == nil {
 		return fmt.Errorf("invalid [cmd] argument: %s", r.Cmd())
-	} else {
-		if value, ok := cmd.(command.Validator); ok {
-			if err := value.Validate(ctx, r); err != nil {
-				return err
-			}
-		}
-		if err := cmd.Execute(ctx, r); err != nil {
+	}
+
+	if value, ok := cmd.(command.Validator); ok {
+		if err := value.Validate(ctx, r); err != nil {
 			return err
 		}
 	}
 
-	return nil
+	return cmd.Execute(ctx, r)
+}
+
+// List implements the optional plugin.Lister interface, used by
+// `posh agent catalog`.
+func (p *Plugin) List(ctx context.Context) []plugin.CommandInfo {
+	ret := make([]plugin.CommandInfo, 0, len(p.commands))
+	for _, cmd := range p.commands.List() {
+		ret = append(ret, plugin.Describe(ctx, cmd.Name(), cmd.Description(), cmd))
+	}
+
+	return ret
+}
+
+// ListSkill implements the optional plugin.SkillLister interface, used by
+// `posh agent skill`. It is List plus the extra markdown each command
+// contributes through the optional command.Skiller interface.
+func (p *Plugin) ListSkill(ctx context.Context) []plugin.SkillCommand {
+	ret := make([]plugin.SkillCommand, 0, len(p.commands))
+	for _, cmd := range p.commands.List() {
+		ret = append(ret, plugin.SkillCommand{
+			CommandInfo: plugin.Describe(ctx, cmd.Name(), cmd.Description(), cmd),
+			Skill:       plugin.Skill(ctx, cmd),
+		})
+	}
+
+	return ret
+}
+
+// SkillMetadata implements the optional plugin.SkillMetadataer interface,
+// supplying the generated SKILL.md frontmatter.
+//
+// Describe what this project's shell is for: the description is what makes an
+// agent reach for the skill, so project vocabulary beats a generic summary.
+// AllowedTools lets posh run without a permission prompt - drop it if the
+// commands here should stay gated.
+func (p *Plugin) SkillMetadata(ctx context.Context) plugin.SkillMetadata {
+	return plugin.SkillMetadata{
+		Description: "Drive the {{.module}} project shell: run project tasks via posh instead of guessing shell commands.",
+		AllowedTools: []string{
+			"Bash(posh execute:*)",
+			"Bash(posh x:*)",
+		},
+	}
 }
 
 func (p *Plugin) Prompt(ctx context.Context, cfg config.Prompt) error {

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -1,13 +1,20 @@
 package cmd
 
 import (
+	"github.com/foomo/posh/pkg/agent"
 	"github.com/foomo/posh/pkg/log"
 	"github.com/spf13/viper"
 )
 
 func NewLogger() log.Logger {
+	level := log.GetLevel(viper.GetString("level"))
+
+	if agent.IsAgentMode() {
+		return log.NewAgentJSON(log.AgentJSONWithLevel(level))
+	}
+
 	return log.NewPTerm(
 		log.PTermWithDisableColor(viper.GetBool("no-color")),
-		log.PTermWithLevel(log.GetLevel(viper.GetString("level"))),
+		log.PTermWithLevel(level),
 	)
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1,0 +1,75 @@
+// Package agent detects whether posh is being driven by an AI coding agent
+// rather than a human, so callers (e.g. cmd/execute.go) can pick agent-friendly
+// defaults such as JSON output instead of human-formatted prose.
+package agent
+
+import (
+	"os"
+	"strings"
+)
+
+// harnessEnvVars lists environment variables set by known agent harnesses.
+// Presence of any of these (non-empty) is treated as a signal that posh is
+// running under an agent, absent an explicit POSH_AGENT_MODE override.
+var harnessEnvVars = []string{
+	"CLAUDECODE",
+	"CURSOR_AGENT",
+	"GITHUB_COPILOT",
+	"AMAZON_Q",
+	"OPENCODE",
+}
+
+var (
+	detected bool
+	flagSet  bool
+)
+
+func init() {
+	detected = DetectFrom(os.Getenv)
+}
+
+// DetectFrom resolves agent mode using the given environment lookup. An
+// explicit POSH_AGENT_MODE wins over harness detection in both directions.
+// Exported so detection logic is testable without mutating the real process
+// environment.
+func DetectFrom(getenv func(string) string) bool {
+	switch strings.ToLower(getenv("POSH_AGENT_MODE")) {
+	case "0", "false", "no":
+		return false
+	case "1", "true", "yes":
+		return true
+	}
+
+	for _, name := range harnessEnvVars {
+		if getenv(name) != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// SetFlag records an explicit --agent flag, e.g. for harnesses that set none
+// of the recognized environment variables.
+func SetFlag(v bool) {
+	flagSet = v
+}
+
+// IsAgentMode reports whether posh should behave as if driven by an agent.
+func IsAgentMode() bool {
+	return detected || flagSet
+}
+
+// SetDetected overrides the environment-based detection performed in init and
+// returns a func restoring the previous value.
+//
+// This exists for tests: inside an agent harness the real environment sets
+// CLAUDECODE, so IsAgentMode reports true for the whole test binary and the
+// human-formatted output path would be unreachable. Production code should let
+// init do the detection and use POSH_AGENT_MODE to override it.
+func SetDetected(v bool) func() {
+	prev := detected
+	detected = v
+
+	return func() { detected = prev }
+}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1,0 +1,43 @@
+package agent_test
+
+import (
+	"testing"
+
+	"github.com/foomo/posh/pkg/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectFrom(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{name: "no signal", env: map[string]string{}, want: false},
+		{name: "harness env var set", env: map[string]string{"CLAUDECODE": "1"}, want: true},
+		{name: "unrelated env var set", env: map[string]string{"HOME": "/root"}, want: false},
+		{name: "explicit override true", env: map[string]string{"POSH_AGENT_MODE": "true"}, want: true},
+		{
+			name: "explicit override false wins over harness var",
+			env:  map[string]string{"POSH_AGENT_MODE": "0", "CLAUDECODE": "1"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getenv := func(key string) string { return tt.env[key] }
+
+			assert.Equal(t, tt.want, agent.DetectFrom(getenv))
+		})
+	}
+}
+
+func TestIsAgentMode(t *testing.T) {
+	t.Run("explicit flag forces true", func(t *testing.T) {
+		agent.SetFlag(true)
+		defer agent.SetFlag(false)
+
+		assert.True(t, agent.IsAgentMode())
+	})
+}

--- a/pkg/agent/encode.go
+++ b/pkg/agent/encode.go
@@ -1,0 +1,27 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// Encode writes v to stdout as a single JSON value followed by a newline.
+//
+// Commands use this in agent mode to emit one machine-readable value instead of
+// the human-formatted PTerm tables and trees they render otherwise. Results are
+// emitted bare: a caller invoked a specific command and already knows what it
+// asked for. Log lines written by pkg/log.AgentJSON keep a "type" field, which
+// is what lets a consumer tell an interleaved log line from the result value.
+//
+// Encode does not itself check agent mode - callers branch on IsAgentMode, and
+// `posh agent catalog` uses it unconditionally.
+//
+// HTML escaping is disabled to match pkg/log.AgentJSON: environment values and
+// cache contents routinely contain characters like & and < that would otherwise
+// be mangled into escape sequences.
+func Encode(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetEscapeHTML(false)
+
+	return enc.Encode(v)
+}

--- a/pkg/agent/flags.go
+++ b/pkg/agent/flags.go
@@ -1,0 +1,9 @@
+package agent
+
+// Flag is the command-line flag that forces agent mode on, for harnesses that
+// set none of the recognized environment variables.
+//
+// It is exported so callers scanning argv by hand - see
+// readline.ExtractFlags, needed where cobra's DisableFlagParsing stops flags
+// being populated - do not restate the literal.
+const Flag = "--agent"

--- a/pkg/agent/flags_test.go
+++ b/pkg/agent/flags_test.go
@@ -1,0 +1,28 @@
+package agent_test
+
+import (
+	"testing"
+
+	"github.com/foomo/posh/pkg/agent"
+	"github.com/foomo/posh/pkg/readline"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFlag_SetsAgentMode covers the wiring the posh CLI relies on: a leading
+// agent.Flag scanned off argv turns agent mode on. The scan itself is tested in
+// pkg/readline.
+func TestFlag_SetsAgentMode(t *testing.T) {
+	defer agent.SetFlag(false)
+
+	restore := agent.SetDetected(false)
+	defer restore()
+
+	agent.SetFlag(false)
+
+	rest := readline.ExtractFlags([]string{agent.Flag, "welcome"}, map[string]func(){
+		agent.Flag: func() { agent.SetFlag(true) },
+	})
+
+	assert.Equal(t, []string{"welcome"}, rest)
+	assert.True(t, agent.IsAgentMode())
+}

--- a/pkg/agent/render.go
+++ b/pkg/agent/render.go
@@ -1,0 +1,24 @@
+package agent
+
+// Render emits a command's result in whichever form the caller is expecting:
+// the JSON payload in agent mode, the human-formatted output otherwise.
+//
+// It exists so commands do not each carry their own `if agent.IsAgentMode()`.
+// Both sides are closures, so only the branch actually taken does its work -
+// building a payload or walking a cache is not paid for when the other form
+// wins.
+//
+// Payloads are emitted bare by Encode, without a type/schema_version envelope:
+// a caller invoked a specific command and already knows what it asked for.
+//
+//	return agent.Render(
+//		func() any { return CacheGet{Namespace: ns, Key: key, Value: value} },
+//		func() error { c.l.Info(fmt.Sprintf("%v", value)); return nil },
+//	)
+func Render(payload func() any, human func() error) error {
+	if IsAgentMode() {
+		return Encode(payload())
+	}
+
+	return human()
+}

--- a/pkg/agent/render_test.go
+++ b/pkg/agent/render_test.go
@@ -1,0 +1,83 @@
+package agent_test
+
+import (
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/foomo/posh/pkg/agent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRender_AgentMode(t *testing.T) {
+	restore := agent.SetDetected(true)
+	defer restore()
+
+	var humanCalled bool
+
+	out := captureStdout(t, func() {
+		require.NoError(t, agent.Render(
+			func() any { return map[string]string{"key": "value"} },
+			func() error { humanCalled = true; return nil },
+		))
+	})
+
+	assert.False(t, humanCalled, "the human closure must not run in agent mode")
+	assert.JSONEq(t, `{"key":"value"}`, out)
+}
+
+func TestRender_HumanMode(t *testing.T) {
+	restore := agent.SetDetected(false)
+	defer restore()
+
+	var payloadCalled bool
+
+	out := captureStdout(t, func() {
+		require.NoError(t, agent.Render(
+			func() any { payloadCalled = true; return nil },
+			func() error { return nil },
+		))
+	})
+
+	assert.False(t, payloadCalled, "the payload must not be built in human mode")
+	assert.Empty(t, out)
+}
+
+func TestRender_HumanErrorPropagates(t *testing.T) {
+	restore := agent.SetDetected(false)
+	defer restore()
+
+	want := errors.New("boom")
+	got := agent.Render(func() any { return nil }, func() error { return want })
+
+	assert.Equal(t, want, got)
+}
+
+// captureStdout swaps the process stdout for a pipe. The JSON encoder writes to
+// the real descriptor, so a writer-only capture would miss it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	orig := os.Stdout
+	os.Stdout = w
+
+	done := make(chan string, 1)
+
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+
+	return <-done
+}

--- a/pkg/agent/table.go
+++ b/pkg/agent/table.go
@@ -1,0 +1,102 @@
+package agent
+
+import (
+	"github.com/pterm/pterm"
+)
+
+type tableOptions struct {
+	hasHeader bool
+}
+
+// TableOption configures Table.
+type TableOption func(*tableOptions)
+
+// WithHeader marks the first row of the data as a header row. In agent mode the
+// header cells become the JSON object keys; without it rows are emitted as
+// positional arrays.
+func WithHeader() TableOption {
+	return func(o *tableOptions) {
+		o.hasHeader = true
+	}
+}
+
+// Table renders tabular data, emitting JSON in agent mode and a PTerm table
+// otherwise.
+//
+// Commands should prefer this over calling pterm.DefaultTable directly: PTerm
+// writes human-formatted, colored text that an agent cannot parse, and this
+// keeps both paths in one call rather than requiring every command to branch.
+//
+// With WithHeader, rows are emitted as objects keyed by the header cells:
+//
+//	{"rows":[{"Name":"prod","Status":"ok"}]}
+//
+// Without it, rows are emitted as positional arrays:
+//
+//	{"rows":[["prod","ok"]]}
+//
+// Unlike the PTerm path, cell values are never wrapped or truncated to the
+// terminal width, which would corrupt long values with embedded newlines.
+func Table(data pterm.TableData, opts ...TableOption) error {
+	var o tableOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	return Render(
+		func() any { return TableRows(data, o.hasHeader) },
+		func() error {
+			printer := pterm.DefaultTable.WithData(data)
+			if o.hasHeader {
+				printer = printer.WithHasHeader(true).WithHeaderRowSeparator("-")
+			}
+
+			return printer.Render()
+		},
+	)
+}
+
+// TableJSON is the agent-mode representation of a table. Rows are either
+// map[string]string (with a header) or []string (without).
+type TableJSON struct {
+	Rows []any `json:"rows"`
+}
+
+// TableRows converts PTerm table data into its agent-mode representation.
+//
+// It is exported for commands that need to embed rows in a larger payload
+// rather than emit a table on its own; most callers want Table instead.
+func TableRows(data pterm.TableData, hasHeader bool) TableJSON {
+	ret := TableJSON{Rows: []any{}}
+
+	if len(data) == 0 {
+		return ret
+	}
+
+	if !hasHeader {
+		for _, row := range data {
+			ret.Rows = append(ret.Rows, row)
+		}
+
+		return ret
+	}
+
+	header, body := data[0], data[1:]
+
+	for _, row := range body {
+		entry := make(map[string]string, len(header))
+
+		for i, key := range header {
+			if i < len(row) {
+				entry[key] = row[i]
+			} else {
+				// Ragged row: emit the key so consumers see a stable shape.
+				entry[key] = ""
+			}
+		}
+
+		ret.Rows = append(ret.Rows, entry)
+	}
+
+	return ret
+}

--- a/pkg/agent/tabletree_test.go
+++ b/pkg/agent/tabletree_test.go
@@ -1,0 +1,133 @@
+package agent_test
+
+import (
+	"testing"
+
+	"github.com/foomo/posh/pkg/agent"
+	"github.com/pterm/pterm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableRows_WithHeader(t *testing.T) {
+	got := agent.TableRows(pterm.TableData{
+		{"Name", "Status"},
+		{"prod", "ok"},
+		{"dev", "down"},
+	}, true)
+
+	require.Len(t, got.Rows, 2)
+	assert.Equal(t, map[string]string{"Name": "prod", "Status": "ok"}, got.Rows[0])
+	assert.Equal(t, map[string]string{"Name": "dev", "Status": "down"}, got.Rows[1])
+}
+
+func TestTableRows_WithoutHeader(t *testing.T) {
+	got := agent.TableRows(pterm.TableData{
+		{"prod", "ok"},
+	}, false)
+
+	require.Len(t, got.Rows, 1)
+	assert.Equal(t, []string{"prod", "ok"}, got.Rows[0])
+}
+
+func TestTableRows_RaggedRow(t *testing.T) {
+	got := agent.TableRows(pterm.TableData{
+		{"Name", "Status"},
+		{"prod"},
+	}, true)
+
+	require.Len(t, got.Rows, 1)
+	assert.Equal(t, map[string]string{"Name": "prod", "Status": ""}, got.Rows[0])
+}
+
+func TestTableRows_Empty(t *testing.T) {
+	got := agent.TableRows(pterm.TableData{}, true)
+
+	assert.NotNil(t, got.Rows, "must encode as [] rather than null")
+	assert.Empty(t, got.Rows)
+}
+
+func TestTreeNodes_Nesting(t *testing.T) {
+	got := agent.TreeNodes(pterm.LeveledList{
+		{Level: 0, Text: "alpha"},
+		{Level: 1, Text: "one"},
+		{Level: 2, Text: "deep"},
+		{Level: 1, Text: "two"},
+		{Level: 0, Text: "beta"},
+	})
+
+	require.Len(t, got.Nodes, 2)
+
+	assert.Equal(t, "alpha", got.Nodes[0].Text)
+	require.Len(t, got.Nodes[0].Children, 2)
+	assert.Equal(t, "one", got.Nodes[0].Children[0].Text)
+
+	require.Len(t, got.Nodes[0].Children[0].Children, 1)
+	assert.Equal(t, "deep", got.Nodes[0].Children[0].Children[0].Text)
+
+	assert.Equal(t, "two", got.Nodes[0].Children[1].Text)
+	assert.Empty(t, got.Nodes[0].Children[1].Children)
+
+	assert.Equal(t, "beta", got.Nodes[1].Text)
+	assert.Empty(t, got.Nodes[1].Children)
+}
+
+// TestTreeNodes_ManyRoots guards against pointers into a slice that append
+// reallocates: with enough roots the backing array grows, and a parent pointer
+// captured before the growth would write into the discarded array.
+func TestTreeNodes_ManyRoots(t *testing.T) {
+	var list pterm.LeveledList
+	for i := range 64 {
+		list = append(list,
+			pterm.LeveledListItem{Level: 0, Text: string(rune('a' + i%26))},
+			pterm.LeveledListItem{Level: 1, Text: "child"},
+		)
+	}
+
+	got := agent.TreeNodes(list)
+
+	require.Len(t, got.Nodes, 64)
+
+	for i, node := range got.Nodes {
+		require.Len(t, node.Children, 1, "root %d lost its child", i)
+		assert.Equal(t, "child", node.Children[0].Text)
+	}
+}
+
+// TestTreeNodes_ManyChildren is the same hazard one level down.
+func TestTreeNodes_ManyChildren(t *testing.T) {
+	list := pterm.LeveledList{{Level: 0, Text: "root"}}
+	for range 64 {
+		list = append(list,
+			pterm.LeveledListItem{Level: 1, Text: "child"},
+			pterm.LeveledListItem{Level: 2, Text: "grandchild"},
+		)
+	}
+
+	got := agent.TreeNodes(list)
+
+	require.Len(t, got.Nodes, 1)
+	require.Len(t, got.Nodes[0].Children, 64)
+
+	for i, child := range got.Nodes[0].Children {
+		require.Len(t, child.Children, 1, "child %d lost its grandchild", i)
+	}
+}
+
+func TestTreeNodes_SkippedLevel(t *testing.T) {
+	got := agent.TreeNodes(pterm.LeveledList{
+		{Level: 0, Text: "root"},
+		{Level: 3, Text: "jumped"},
+	})
+
+	require.Len(t, got.Nodes, 1)
+	require.Len(t, got.Nodes[0].Children, 1)
+	assert.Equal(t, "jumped", got.Nodes[0].Children[0].Text)
+}
+
+func TestTreeNodes_Empty(t *testing.T) {
+	got := agent.TreeNodes(pterm.LeveledList{})
+
+	assert.NotNil(t, got.Nodes, "must encode as [] rather than null")
+	assert.Empty(t, got.Nodes)
+}

--- a/pkg/agent/tree.go
+++ b/pkg/agent/tree.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"github.com/pterm/pterm"
+	"github.com/pterm/pterm/putils"
+)
+
+// TreeNode is the agent-mode representation of a single tree entry.
+type TreeNode struct {
+	Text     string     `json:"text"`
+	Children []TreeNode `json:"children,omitempty"`
+}
+
+// TreeJSON is the agent-mode representation of a tree.
+type TreeJSON struct {
+	Nodes []TreeNode `json:"nodes"`
+}
+
+// Tree renders a leveled list, emitting nested JSON in agent mode and a PTerm
+// tree otherwise.
+//
+// Commands should prefer this over calling pterm.DefaultTree directly: PTerm
+// draws box-drawing characters an agent cannot parse, and this keeps both paths
+// in one call rather than requiring every command to branch.
+//
+// The flat, level-based pterm.LeveledList is rebuilt into real nesting:
+//
+//	{"nodes":[{"text":"kubectl","children":[{"text":"clusters"}]}]}
+func Tree(list pterm.LeveledList) error {
+	return Render(
+		func() any { return TreeNodes(list) },
+		func() error {
+			return pterm.DefaultTree.WithRoot(putils.TreeFromLeveledList(list)).Render()
+		},
+	)
+}
+
+// TreeNodes converts a leveled list into its nested agent-mode representation.
+//
+// It is exported for commands that need to embed a tree in a larger payload
+// rather than emit one on its own; most callers want Tree instead.
+//
+// Items whose level skips more than one step below their predecessor are
+// attached to the nearest available parent, matching how PTerm renders them
+// rather than rejecting input a command already considers valid.
+func TreeNodes(list pterm.LeveledList) TreeJSON {
+	ret := TreeJSON{Nodes: []TreeNode{}}
+
+	// parents[i] is the node currently open at level i; appending to its
+	// Children requires a pointer, since TreeNode values are copied.
+	var parents []*TreeNode
+
+	for _, item := range list {
+		node := TreeNode{Text: item.Text}
+
+		// Clamped into range: a negative level is treated as a root, and one
+		// that skips more than a step falls back to the deepest open parent.
+		level := min(max(item.Level, 0), len(parents))
+
+		if level == 0 {
+			ret.Nodes = append(ret.Nodes, node)
+			parents = []*TreeNode{&ret.Nodes[len(ret.Nodes)-1]}
+
+			continue
+		}
+
+		parent := parents[level-1]
+		parent.Children = append(parent.Children, node)
+
+		parents = append(parents[:level], &parent.Children[len(parent.Children)-1])
+	}
+
+	return ret
+}

--- a/pkg/command/cache.go
+++ b/pkg/command/cache.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/foomo/posh/pkg/agent"
 	"github.com/foomo/posh/pkg/cache"
 	"github.com/foomo/posh/pkg/command/tree"
 	"github.com/foomo/posh/pkg/log"
@@ -12,7 +13,6 @@ import (
 	"github.com/foomo/posh/pkg/readline"
 	"github.com/foomo/posh/pkg/util/suggests"
 	"github.com/pterm/pterm"
-	"github.com/pterm/pterm/putils"
 	"github.com/samber/lo"
 )
 
@@ -56,6 +56,27 @@ func NewCache(l log.Logger, cache cache.Cache) *Cache {
 				Description: "List all caches",
 				Execute:     inst.list,
 			},
+			{
+				Name:        "get",
+				Description: "Get a cached value",
+				Args: tree.Args{
+					{
+						Name:        "Namespace",
+						Description: "Name of the namespace.",
+						Suggest: func(ctx context.Context, t tree.Root, r *readline.Readline) []goprompt.Suggest {
+							return suggests.List(lo.Keys(inst.cache.List()))
+						},
+					},
+					{
+						Name:        "Key",
+						Description: "Name of the cached key.",
+						Suggest: func(ctx context.Context, t tree.Root, r *readline.Readline) []goprompt.Suggest {
+							return suggests.List(inst.cache.Get(r.Args().At(1)).Keys())
+						},
+					},
+				},
+				Execute: inst.get,
+			},
 		},
 	})
 
@@ -72,6 +93,29 @@ func (c *Cache) Name() string {
 
 func (c *Cache) Description() string {
 	return c.tree.Node().Description
+}
+
+// Describe implements the optional Describer interface, letting
+// `posh agent catalog` describe this command's subtree.
+func (c *Cache) Describe(ctx context.Context) CommandInfo {
+	return c.tree.Describe(ctx)
+}
+
+// Skill implements the optional Skiller interface. The catalog already carries
+// the structure; what it cannot show is that the namespaces are populated at
+// runtime, which is what makes `cache list` the necessary first step.
+func (c *Cache) Skill(ctx context.Context) string {
+	return "#### Notes\n\n" +
+		"The cache is in-memory and per shell process: it is empty on start and is\n" +
+		"lost on exit, so it never needs clearing between sessions.\n\n" +
+		"Namespaces are created by whichever command populates them, so they cannot\n" +
+		"be listed ahead of time - run `cache list` to discover the namespaces and\n" +
+		"keys that currently exist, then `cache get [Namespace] [Key]` to read one\n" +
+		"value. `cache list` prints keys only; it never prints values.\n\n" +
+		"`cache clear` with no argument drops every namespace. Prefer naming the\n" +
+		"namespaces to clear - it accepts several - so unrelated cached lookups are\n" +
+		"not discarded with them. Clearing is safe: the next command that needs a\n" +
+		"value recomputes it, the only cost is the recomputation."
 }
 
 func (c *Cache) Complete(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
@@ -114,15 +158,62 @@ func (c *Cache) clear(ctx context.Context, r *readline.Readline) error {
 	return nil
 }
 
-func (c *Cache) list(ctx context.Context, r *readline.Readline) error {
-	// Create a fork of the default table, fill it with data and print it.
-	// Data can also be generated and inserted later.
-	list := pterm.LeveledList{}
-	cacheList := c.cache.List()
-	cacheListKeys := lo.Keys(cacheList)
-	sort.Strings(cacheListKeys)
+// get prints a single cached value. Values are otherwise only visible in the
+// list at trace level, so this is the way to inspect one.
+func (c *Cache) get(ctx context.Context, r *readline.Readline) error {
+	namespace, key := r.Args().At(1), r.Args().At(2)
+	// A nil callback returns the cached value without populating it.
+	value := c.cache.Get(namespace).Get(key, nil)
 
-	for _, ns := range cacheListKeys {
+	return agent.Render(
+		func() any { return CacheGet{Namespace: namespace, Key: key, Value: value} },
+		func() error {
+			c.l.Info(fmt.Sprintf("%v", value))
+			return nil
+		},
+	)
+}
+
+func (c *Cache) list(ctx context.Context, r *readline.Readline) error {
+	cacheList := c.cache.List()
+	namespaces := lo.Keys(cacheList)
+	sort.Strings(namespaces)
+
+	return agent.Render(
+		func() any { return c.listPayload(cacheList, namespaces) },
+		func() error { return c.listTree(cacheList, namespaces) },
+	)
+}
+
+// listPayload builds the JSON form. Only keys are included, mirroring the tree
+// at default level - use `cache get` to read a value.
+//
+// It is namespace-keyed rather than reusing agent.Tree: the generic
+// {"text","children"} shape would make a consumer index into anonymous nodes to
+// find a namespace.
+func (c *Cache) listPayload(cacheList map[string]cache.Namespace, namespaces []string) CacheList {
+	values := make([]CacheNamespace, 0, len(namespaces))
+
+	for _, ns := range namespaces {
+		keys := cacheList[ns].Keys()
+		sort.Strings(keys)
+
+		if keys == nil {
+			keys = []string{}
+		}
+
+		values = append(values, CacheNamespace{Namespace: ns, Keys: keys})
+	}
+
+	return CacheList{Namespaces: values}
+}
+
+// listTree renders the human-formatted tree, including cached values at trace
+// level.
+func (c *Cache) listTree(cacheList map[string]cache.Namespace, namespaces []string) error {
+	list := pterm.LeveledList{}
+
+	for _, ns := range namespaces {
 		value := cacheList[ns]
 		list = append(list, pterm.LeveledListItem{Level: 0, Text: ns})
 		keys := value.Keys()
@@ -135,9 +226,6 @@ func (c *Cache) list(ctx context.Context, r *readline.Readline) error {
 			}
 		}
 	}
-	// Generate tree from LeveledList.
-	root := putils.TreeFromLeveledList(list)
 
-	// Render TreePrinter
-	return pterm.DefaultTree.WithRoot(root).Render()
+	return agent.Tree(list)
 }

--- a/pkg/command/cache_test.go
+++ b/pkg/command/cache_test.go
@@ -1,0 +1,89 @@
+package command_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/foomo/posh/pkg/cache"
+	"github.com/foomo/posh/pkg/command"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testCache(t *testing.T) cache.Cache {
+	t.Helper()
+
+	c := cache.NewMemoryCache()
+	// A nil callback reads without populating, so seed with a real one.
+	c.Get("alpha").Get("one", func() any { return "secret-value" })
+	c.Get("beta").Get("two", func() any { return 42 })
+
+	return c
+}
+
+func TestCache_ListAgent_KeysOnly(t *testing.T) {
+	c := testCache(t)
+
+	out := captureAgent(t, func() {
+		l := newTestLogger()
+		require.NoError(t, command.NewCache(l, c).Execute(t.Context(), parse(t, l, "cache list")))
+	})
+
+	var got command.CacheList
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+
+	require.Len(t, got.Namespaces, 2)
+
+	// Sorted by namespace.
+	assert.Equal(t, "alpha", got.Namespaces[0].Namespace)
+	assert.Equal(t, []string{"one"}, got.Namespaces[0].Keys)
+	assert.Equal(t, "beta", got.Namespaces[1].Namespace)
+
+	// Keys only: no cached value may appear anywhere in the payload.
+	assert.NotContains(t, out, "secret-value")
+}
+
+func TestCache_GetAgent(t *testing.T) {
+	c := testCache(t)
+
+	out := captureAgent(t, func() {
+		l := newTestLogger()
+		require.NoError(t, command.NewCache(l, c).Execute(t.Context(), parse(t, l, "cache get alpha one")))
+	})
+
+	var got command.CacheGet
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+
+	assert.Equal(t, "alpha", got.Namespace)
+	assert.Equal(t, "one", got.Key)
+	assert.Equal(t, "secret-value", got.Value)
+}
+
+func TestCache_GetAgent_MissingKey(t *testing.T) {
+	out := captureAgent(t, func() {
+		l := newTestLogger()
+		require.NoError(t, command.NewCache(l, testCache(t)).Execute(t.Context(), parse(t, l, "cache get alpha nope")))
+	})
+
+	var got command.CacheGet
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+
+	assert.Nil(t, got.Value, "a missing key yields null rather than an error")
+}
+
+// TestCache_ListHuman verifies the non-agent path renders via PTerm rather than
+// emitting JSON. PTerm writes through its own cached writer instead of the
+// os.Stdout we swap, so its output does not reach the pipe - the assertion is
+// that no JSON envelope was produced.
+func TestCache_ListHuman(t *testing.T) {
+	c := testCache(t)
+
+	out := captureHuman(t, func() {
+		l := newTestLogger()
+		require.NoError(t, command.NewCache(l, c).Execute(t.Context(), parse(t, l, "cache list")))
+	})
+
+	// Results are emitted bare, so there is no envelope to key on: assert the
+	// output is not the JSON payload at all.
+	assert.NotContains(t, out, `"namespaces"`)
+}

--- a/pkg/command/check.go
+++ b/pkg/command/check.go
@@ -3,11 +3,13 @@ package command
 import (
 	"context"
 
+	"github.com/foomo/posh/pkg/agent"
 	"github.com/foomo/posh/pkg/command/tree"
 	"github.com/foomo/posh/pkg/log"
 	"github.com/foomo/posh/pkg/prompt/check"
 	"github.com/foomo/posh/pkg/prompt/goprompt"
 	"github.com/foomo/posh/pkg/readline"
+	"github.com/foomo/posh/pkg/util"
 )
 
 type (
@@ -26,8 +28,9 @@ type (
 
 func NewCheck(l log.Logger, checkers ...check.Checker) *Check {
 	inst := &Check{
-		l:        l,
-		check:    check.DefaultCheck,
+		l: l,
+		// AgentCheck emits the same results as JSON; DefaultCheck renders a table.
+		check:    util.Pick(agent.IsAgentMode(), check.AgentCheck, check.DefaultCheck),
 		checkers: checkers,
 	}
 	inst.tree = tree.New(&tree.Node{
@@ -49,6 +52,32 @@ func (c *Check) Name() string {
 
 func (c *Check) Description() string {
 	return c.tree.Node().Description
+}
+
+// Describe implements the optional Describer interface, letting
+// `posh agent catalog` describe this command's subtree.
+func (c *Check) Describe(ctx context.Context) CommandInfo {
+	return c.tree.Describe(ctx)
+}
+
+// Skill implements the optional Skiller interface. The command takes no
+// arguments, so its structure says nothing - what an agent needs is that this
+// is the diagnostic to reach for first, and that the checks are project
+// defined.
+func (c *Check) Skill(ctx context.Context) string {
+	return "#### Notes\n\n" +
+		"Runs this project's environment checks - the same ones the interactive\n" +
+		"shell prints on startup - reporting each as `success`, `failure`,\n" +
+		"`warning` or `note`. Which checks exist is defined by this project, so\n" +
+		"they cover whatever it actually depends on: required binaries,\n" +
+		"credentials, cluster reachability.\n\n" +
+		"Run this first when another command fails for an environment-shaped\n" +
+		"reason: a missing tool, an expired login, an unreachable service. It is\n" +
+		"read-only and changes nothing, so it is always safe to run.\n\n" +
+		"A failing check is a report, not an error: the command still exits 0. Read\n" +
+		"the results rather than relying on the exit code. Fixing a failure usually\n" +
+		"means acting outside posh - installing the tool, re-authenticating - and\n" +
+		"posh cannot do that for you."
 }
 
 func (c *Check) Complete(ctx context.Context, r *readline.Readline) []goprompt.Suggest {

--- a/pkg/command/check_test.go
+++ b/pkg/command/check_test.go
@@ -1,0 +1,78 @@
+package command_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/foomo/posh/pkg/command"
+	"github.com/foomo/posh/pkg/log"
+	"github.com/foomo/posh/pkg/prompt/check"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheck_RunAgent(t *testing.T) {
+	// Two checkers, deliberately out of alphabetical order.
+	zulu := func(ctx context.Context, l log.Logger) []check.Info {
+		return []check.Info{check.NewFailureInfo("⚡︎", "zulu", "down")}
+	}
+	alpha := func(ctx context.Context, l log.Logger) []check.Info {
+		return []check.Info{check.NewSuccessInfo("⚫︎", "alpha", "ok")}
+	}
+
+	out := captureAgent(t, func() {
+		l := newTestLogger()
+		require.NoError(t, command.NewCheck(l, zulu, alpha).Execute(t.Context(), parse(t, l, "check")))
+	})
+
+	var got check.Results
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+
+	require.Len(t, got.Checks, 2)
+
+	// Sorted by name, matching the PTerm path.
+	assert.Equal(t, "alpha", got.Checks[0].Name)
+	assert.Equal(t, "ok", got.Checks[0].Note)
+	assert.Equal(t, "success", got.Checks[0].Status)
+
+	assert.Equal(t, "zulu", got.Checks[1].Name)
+	assert.Equal(t, "failure", got.Checks[1].Status)
+
+	// Icons are presentation and must not leak into the payload.
+	assert.NotContains(t, out, "⚫︎")
+}
+
+func TestCheck_RunAgent_NoCheckers(t *testing.T) {
+	out := captureAgent(t, func() {
+		l := newTestLogger()
+		require.NoError(t, command.NewCheck(l).Execute(t.Context(), parse(t, l, "check")))
+	})
+
+	var got check.Results
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+
+	assert.NotNil(t, got.Checks, "an empty result must encode as [] rather than null")
+	assert.Empty(t, got.Checks)
+}
+
+// TestCheck_RunHuman verifies the non-agent path still goes through check.Check.
+func TestCheck_RunHuman(t *testing.T) {
+	var called bool
+
+	l := newTestLogger()
+
+	// NewCheck picks its check.Check at construction, so it must be built
+	// inside captureHuman - while agent mode is off.
+	out := captureHuman(t, func() {
+		c := command.NewCheck(l, func(ctx context.Context, l log.Logger) []check.Info {
+			called = true
+			return []check.Info{check.NewSuccessInfo("⚫︎", "alpha", "ok")}
+		})
+
+		require.NoError(t, c.Execute(t.Context(), parse(t, l, "check")))
+	})
+
+	assert.True(t, called, "the checker still runs through check.Check")
+	assert.NotContains(t, out, `"checks"`, "no JSON payload on the human path")
+}

--- a/pkg/command/describe.go
+++ b/pkg/command/describe.go
@@ -1,0 +1,51 @@
+package command
+
+import (
+	"context"
+
+	"github.com/foomo/posh/pkg/command/tree"
+)
+
+// Describer is an optional Command extension: a command that describes its own
+// structure for `posh agent catalog`, so an AI coding agent gets a
+// machine-readable answer to "what can I run" without parsing help text.
+//
+// The contract is CommandInfo, not a command tree: a command is free to model
+// its structure however it likes and stays free to change that later. Tree
+// based commands delegate to tree.Root.Describe like any other tree method:
+//
+//	func (c *Cache) Describe(ctx context.Context) command.CommandInfo {
+//		return c.tree.Describe(ctx)
+//	}
+//
+// Commands that do not implement it are still listed, just without subcommand
+// detail.
+type Describer interface {
+	Describe(ctx context.Context) CommandInfo
+}
+
+// The catalog shapes are built by the tree walk and aliased here so a command
+// describing itself by hand does not need to import the tree package.
+type (
+	// CommandInfo describes one command for the `posh agent catalog` catalog.
+	CommandInfo = tree.CommandInfo
+	// ArgInfo describes a single positional argument of a command.
+	ArgInfo = tree.ArgInfo
+	// FlagInfo describes a single flag of a command.
+	FlagInfo = tree.FlagInfo
+)
+
+// ------------------------------------------------------------------------------------------------
+// ~ Public methods
+// ------------------------------------------------------------------------------------------------
+
+// Describe builds a CommandInfo for a single command. Commands implementing
+// the optional Describer interface describe themselves; anything else becomes a
+// leaf carrying only its name and description.
+func Describe(ctx context.Context, name, description string, v any) CommandInfo {
+	if d, ok := v.(Describer); ok {
+		return d.Describe(ctx)
+	}
+
+	return CommandInfo{FullPath: name, Description: description}
+}

--- a/pkg/command/describe_test.go
+++ b/pkg/command/describe_test.go
@@ -1,0 +1,43 @@
+package command_test
+
+import (
+	"testing"
+
+	"github.com/foomo/posh/pkg/cache"
+	"github.com/foomo/posh/pkg/command"
+	"github.com/foomo/posh/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// leaf is a command that does not describe itself.
+type leaf struct{}
+
+func (leaf) Name() string        { return "exit" }
+func (leaf) Description() string { return "exit shell" }
+
+// TestDescribe_Leaf covers the fallback: a command that is not a Describer is
+// still listed, just without subcommand detail.
+func TestDescribe_Leaf(t *testing.T) {
+	actual := command.Describe(t.Context(), "exit", "exit shell", leaf{})
+
+	assert.Equal(t, "exit", actual.FullPath)
+	assert.Equal(t, "exit shell", actual.Description)
+	assert.Empty(t, actual.Subcommands)
+	assert.Empty(t, actual.Flags)
+	assert.False(t, actual.Dynamic)
+}
+
+// TestDescribe_Describer covers the dispatch: a Describer describes itself, so
+// the name and description arguments are ignored in favour of the tree's own.
+func TestDescribe_Describer(t *testing.T) {
+	l := log.NewTest(t)
+
+	actual := command.Describe(t.Context(), "ignored", "ignored", command.NewCache(l, cache.NewMemoryCache()))
+
+	assert.Equal(t, "cache", actual.FullPath)
+	assert.Equal(t, "Manage the internal cache", actual.Description)
+
+	require.NotEmpty(t, actual.Subcommands)
+	assert.Equal(t, "cache clear", actual.Subcommands[0].FullPath)
+}

--- a/pkg/command/env.go
+++ b/pkg/command/env.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/foomo/posh/pkg/agent"
 	"github.com/foomo/posh/pkg/command/tree"
 	"github.com/foomo/posh/pkg/log"
 	"github.com/foomo/posh/pkg/prompt/goprompt"
@@ -34,15 +35,19 @@ func NewEnv(l log.Logger) *Env {
 			{
 				Name:        "list",
 				Description: "List all environment variables",
-				Execute:     inst.list,
+				Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+					fs.Default().Bool("with-values", false, "include values in the list")
+					return nil
+				},
+				Execute: inst.list,
 			},
 			{
 				Name:        "get",
 				Description: "Get an environment variable",
 				Args: tree.Args{
 					{
-						Name:        "Key",
-						Description: "Key of the environment variable.",
+						Name:        "key",
+						Description: "Name of the environment variable",
 						Suggest: func(ctx context.Context, t tree.Root, r *readline.Readline) []goprompt.Suggest {
 							return suggests.List(inst.envKeys())
 						},
@@ -55,13 +60,13 @@ func NewEnv(l log.Logger) *Env {
 				Description: "Set an internal environment variable",
 				Args: tree.Args{
 					{
-						Name:        "Key",
-						Description: "Key of the environment variable.",
+						Name:        "key",
+						Description: "Name of the environment variable",
 					},
 					{
-						Name:        "Value",
+						Name:        "value",
 						Optional:    true,
-						Description: "Value of the environment variable.",
+						Description: "Value of the environment variable",
 					},
 				},
 				Execute: inst.set,
@@ -71,8 +76,8 @@ func NewEnv(l log.Logger) *Env {
 				Description: "Unset an environment variable",
 				Args: tree.Args{
 					{
-						Name:        "Key",
-						Description: "Key of the environment variable.",
+						Name:        "key",
+						Description: "Name of the environment variable",
 					},
 				},
 				Execute: inst.unset,
@@ -95,6 +100,32 @@ func (c *Env) Description() string {
 	return c.tree.Node().Description
 }
 
+// Describe implements the optional Describer interface, letting
+// `posh agent catalog` describe this command's subtree.
+func (c *Env) Describe(ctx context.Context) CommandInfo {
+	return c.tree.Describe(ctx)
+}
+
+// Skill implements the optional Skiller interface. The scope of a `set` - this
+// process only - is the thing an agent gets wrong, and no amount of structure
+// conveys it.
+func (c *Env) Skill(ctx context.Context) string {
+	return "#### Notes\n\n" +
+		"These are the environment variables of the running shell process. `env set`\n" +
+		"and `env unset` affect that process and the commands it goes on to run;\n" +
+		"they do not touch your shell, `.env` files, or anything on disk, and the\n" +
+		"change is gone when the shell exits.\n\n" +
+		"That scope matters under `posh execute`: each invocation is a fresh\n" +
+		"process, so `posh x env set FOO bar` followed by a separate\n" +
+		"`posh x env get FOO` will not see the value. To set a variable for a\n" +
+		"command, use the environment of the `posh` invocation itself\n" +
+		"(`FOO=bar posh x ...`). Inside an interactive shell session the value does\n" +
+		"persist across commands.\n\n" +
+		"`env list` prints names only; pass `--with-values` to include values. Do\n" +
+		"that deliberately - the environment routinely holds tokens and\n" +
+		"credentials, and the output goes wherever the transcript goes."
+}
+
 func (c *Env) Complete(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
 	return c.tree.Complete(ctx, r)
 }
@@ -112,8 +143,16 @@ func (c *Env) Help(ctx context.Context, r *readline.Readline) string {
 // ------------------------------------------------------------------------------------------------
 
 func (c *Env) get(ctx context.Context, r *readline.Readline) error {
-	c.l.Info(os.Getenv(r.Args().At(1)))
-	return nil
+	name := r.Args().At(1)
+	value := os.Getenv(name)
+
+	return agent.Render(
+		func() any { return EnvGet{Name: name, Value: value} },
+		func() error {
+			c.l.Info(value)
+			return nil
+		},
+	)
 }
 
 func (c *Env) set(ctx context.Context, r *readline.Readline) error {
@@ -125,13 +164,53 @@ func (c *Env) unset(ctx context.Context, r *readline.Readline) error {
 }
 
 func (c *Env) list(ctx context.Context, r *readline.Readline) error {
-	data := pterm.TableData{{"Name", "Value"}}
+	withValues, err := r.FlagSets().Default().GetBool("with-values")
+	if err != nil {
+		return err
+	}
+
 	values := os.Environ()
 	sort.Strings(values)
 
 	var pairs [][]string
 	for _, s := range values {
 		pairs = append(pairs, strings.SplitN(s, "=", 2))
+	}
+
+	return agent.Render(
+		func() any { return c.listPayload(pairs, withValues) },
+		func() error { return c.listTable(pairs, withValues) },
+	)
+}
+
+// listPayload builds the JSON form. Unlike listTable it never wraps values to
+// the terminal width, which would corrupt long entries such as PATH with
+// embedded newlines.
+func (c *Env) listPayload(pairs [][]string, withValues bool) EnvList {
+	values := make([]EnvVar, 0, len(pairs))
+
+	for _, pair := range pairs {
+		value := EnvVar{Name: pair[0]}
+		if withValues {
+			value.Value = pair[1]
+		}
+
+		values = append(values, value)
+	}
+
+	return EnvList{Values: values}
+}
+
+// listTable renders the human-formatted table, wrapping values to the terminal
+// width so long entries stay inside their column.
+func (c *Env) listTable(pairs [][]string, withValues bool) error {
+	if !withValues {
+		data := pterm.TableData{{"Name"}}
+		for _, pair := range pairs {
+			data = append(data, []string{pair[0]})
+		}
+
+		return agent.Table(data, agent.WithHeader())
 	}
 
 	var maxKeyLen int
@@ -151,9 +230,7 @@ func (c *Env) list(ctx context.Context, r *readline.Readline) error {
 		pairs[i][1] = value.String() + pair[1]
 	}
 
-	data = append(data, pairs...)
-
-	return pterm.DefaultTable.WithHasHeader(true).WithHeaderRowSeparator("-").WithData(data).Render()
+	return agent.Table(append(pterm.TableData{{"Name", "Value"}}, pairs...), agent.WithHeader())
 }
 
 func (c *Env) envKeys() []string {

--- a/pkg/command/env_test.go
+++ b/pkg/command/env_test.go
@@ -1,0 +1,139 @@
+package command_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/foomo/posh/pkg/command"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnv_ListAgent_KeysOnly(t *testing.T) {
+	t.Setenv("POSH_TEST_ENV", "value-one")
+
+	out := captureAgent(t, func() {
+		l := newTestLogger()
+		require.NoError(t, command.NewEnv(l).Execute(t.Context(), parse(t, l, "env list")))
+	})
+
+	var got command.EnvList
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+
+	var found bool
+
+	for _, v := range got.Values {
+		// Without --with-values the value is omitted for every entry.
+		assert.Empty(t, v.Value)
+
+		if v.Name == "POSH_TEST_ENV" {
+			found = true
+		}
+	}
+
+	assert.True(t, found, "expected POSH_TEST_ENV in the listing")
+}
+
+func TestEnv_ListAgent_WithValues(t *testing.T) {
+	// A value longer than any terminal width: the PTerm path wraps values to
+	// the terminal width, which would corrupt this one with newlines.
+	long := strings.Repeat("abcdefghij", 60)
+	t.Setenv("POSH_TEST_LONG", long)
+
+	out := captureAgent(t, func() {
+		l := newTestLogger()
+		require.NoError(t, command.NewEnv(l).Execute(t.Context(), parse(t, l, "env list --with-values")))
+	})
+
+	var got command.EnvList
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+
+	var found bool
+
+	for _, v := range got.Values {
+		if v.Name == "POSH_TEST_LONG" {
+			found = true
+
+			assert.Equal(t, long, v.Value, "value must not be wrapped or truncated")
+		}
+	}
+
+	assert.True(t, found, "expected POSH_TEST_LONG in the listing")
+}
+
+func TestEnv_GetAgent(t *testing.T) {
+	t.Setenv("POSH_TEST_ENV", "value-one")
+
+	out := captureAgent(t, func() {
+		l := newTestLogger()
+		require.NoError(t, command.NewEnv(l).Execute(t.Context(), parse(t, l, "env get POSH_TEST_ENV")))
+	})
+
+	var got command.EnvGet
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+
+	assert.Equal(t, "POSH_TEST_ENV", got.Name)
+	assert.Equal(t, "value-one", got.Value)
+}
+
+func TestEnv_SetUnset(t *testing.T) {
+	ctx := context.Background()
+	l := newTestLogger()
+	c := command.NewEnv(l)
+
+	require.NoError(t, c.Execute(ctx, parse(t, l, "env set POSH_TEST_SET has-value")))
+	assert.Equal(t, "has-value", os.Getenv("POSH_TEST_SET"))
+
+	require.NoError(t, c.Execute(ctx, parse(t, l, "env unset POSH_TEST_SET")))
+
+	_, ok := os.LookupEnv("POSH_TEST_SET")
+	assert.False(t, ok)
+}
+
+// TestEnv_ListHuman verifies the non-agent path renders via PTerm rather than
+// emitting JSON. PTerm writes through its own cached writer instead of the
+// os.Stdout we swap, so its output does not reach the pipe - the assertion is
+// that no JSON envelope was produced.
+func TestEnv_ListHuman(t *testing.T) {
+	t.Setenv("POSH_TEST_ENV", "value-one")
+
+	l := newTestLogger()
+
+	out := captureHuman(t, func() {
+		require.NoError(t, command.NewEnv(l).Execute(t.Context(), parse(t, l, "env list")))
+	})
+
+	// Results are emitted bare, so there is no envelope to key on: assert the
+	// output is not the JSON payload at all.
+	assert.NotContains(t, out, `"values"`)
+}
+
+func TestEnv_GetHuman(t *testing.T) {
+	t.Setenv("POSH_TEST_ENV", "value-one")
+
+	out := captureHuman(t, func() {
+		l := newTestLogger()
+		require.NoError(t, command.NewEnv(l).Execute(t.Context(), parse(t, l, "env get POSH_TEST_ENV")))
+	})
+
+	// The logger writes to os.Stdout directly, so this one is capturable: the
+	// value arrives wrapped in a posh.log envelope rather than as a bare
+	// EnvGet payload.
+	assert.Contains(t, out, "value-one")
+	assert.Contains(t, out, "posh.log")
+	assert.NotContains(t, out, `"name"`)
+}
+
+func TestEnv_GetAgent_NoHTMLEscaping(t *testing.T) {
+	t.Setenv("POSH_TEST_HTML", "a&b<c>d")
+
+	out := captureAgent(t, func() {
+		l := newTestLogger()
+		require.NoError(t, command.NewEnv(l).Execute(t.Context(), parse(t, l, "env get POSH_TEST_HTML")))
+	})
+
+	assert.Contains(t, out, "a&b<c>d", "characters must not be escaped to \\u0026 etc")
+}

--- a/pkg/command/exit.go
+++ b/pkg/command/exit.go
@@ -35,6 +35,17 @@ func (c *Exit) Description() string {
 	return "exit shell"
 }
 
+// Skill implements the optional Skiller interface. It exists to say the command
+// is pointless outside the interactive shell, which its description implies to
+// a human but not to an agent.
+func (c *Exit) Skill(ctx context.Context) string {
+	return "#### Notes\n\n" +
+		"Leaves the interactive posh shell. There is nothing to exit under\n" +
+		"`posh execute`, where each invocation is its own process, so running it\n" +
+		"that way does nothing and succeeds - it is never the way to stop a\n" +
+		"running command."
+}
+
 func (c *Exit) Execute(ctx context.Context, args *readline.Readline) error {
 	return nil
 }

--- a/pkg/command/help.go
+++ b/pkg/command/help.go
@@ -41,6 +41,37 @@ func (c *Help) Description() string {
 	return "print help"
 }
 
+// Describe implements the optional Describer interface. Help is not tree based,
+// so it builds its own CommandInfo - otherwise it would be listed as a bare
+// leaf and its optional [command] argument would not show up at all.
+func (c *Help) Describe(ctx context.Context) CommandInfo {
+	return CommandInfo{
+		FullPath:    c.name,
+		Description: c.Description(),
+		Arguments: []ArgInfo{
+			{
+				Name:        "command",
+				Description: "Name of the command to print help for.",
+				Optional:    true,
+			},
+		},
+	}
+}
+
+// Skill implements the optional Skiller interface, mainly to steer an agent
+// away from this command: the catalog it already has is strictly better
+// structured than the prose this prints.
+func (c *Help) Skill(ctx context.Context) string {
+	return "#### Notes\n\n" +
+		"Prints human-formatted help: with no argument, the list of commands that\n" +
+		"provide help; with one, that command's own help text.\n\n" +
+		"As an agent you rarely need this. `posh agent catalog` covers the same\n" +
+		"ground as structured JSON - every command, its arguments and its flags,\n" +
+		"including the many commands that provide no help text and so never appear\n" +
+		"in the list here. Reach for `help [command]` only for prose a specific\n" +
+		"command wrote that the catalog does not carry."
+}
+
 func (c *Help) Complete(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
 	var suggests []goprompt.Suggest
 

--- a/pkg/command/helper_test.go
+++ b/pkg/command/helper_test.go
@@ -1,0 +1,85 @@
+package command_test
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/foomo/posh/pkg/agent"
+	"github.com/foomo/posh/pkg/log"
+	"github.com/foomo/posh/pkg/readline"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestLogger() log.Logger {
+	return log.NewAgentJSON(log.AgentJSONWithLevel(log.LevelInfo))
+}
+
+// parse builds a Readline from a command line, wiring up the flag sets the way
+// the prompt does so that flags such as --with-values are available.
+func parse(t *testing.T, l log.Logger, input string) *readline.Readline {
+	t.Helper()
+
+	r, err := readline.New(l)
+	require.NoError(t, err)
+	require.NoError(t, r.Parse(input))
+
+	return r
+}
+
+// captureStdout swaps the process stdout file descriptor for a pipe and returns
+// everything written while fn runs.
+//
+// It captures the real descriptor rather than a logger writer because PTerm
+// writes to os.Stdout directly: a writer-only capture would miss the
+// human-formatted output entirely and silently pass.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	orig := os.Stdout
+	os.Stdout = w
+
+	done := make(chan string, 1)
+
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	// Restore stdout and drain the pipe even if fn panics.
+	defer func() {
+		os.Stdout = orig
+	}()
+
+	fn()
+
+	require.NoError(t, w.Close())
+
+	return <-done
+}
+
+// captureAgent forces agent mode for the duration of fn and returns what was
+// written to stdout.
+func captureAgent(t *testing.T, fn func()) string {
+	t.Helper()
+
+	restore := agent.SetDetected(true)
+	defer restore()
+
+	return captureStdout(t, fn)
+}
+
+// captureHuman forces human mode for the duration of fn and returns what was
+// written to stdout. Needed because the test binary itself usually runs inside
+// an agent harness.
+func captureHuman(t *testing.T, fn func()) string {
+	t.Helper()
+
+	restore := agent.SetDetected(false)
+	defer restore()
+
+	return captureStdout(t, fn)
+}

--- a/pkg/command/history.go
+++ b/pkg/command/history.go
@@ -39,6 +39,25 @@ func (c *History) Description() string {
 	return "show history"
 }
 
+// Skill implements the optional Skiller interface. What the one-line
+// description cannot say is whose history this is, and that it is a record of
+// intent rather than of success.
+func (c *History) Skill(ctx context.Context) string {
+	return "#### Notes\n\n" +
+		"Prints the commands previously entered in this project's interactive posh\n" +
+		"shell, oldest last. It is normally file-backed (`.posh/history`) and so\n" +
+		"survives across sessions, which makes it the best source for the real\n" +
+		"invocations of a command - arguments and all - rather than guessing them\n" +
+		"from the catalog.\n\n" +
+		"Read it with two caveats. It records what was entered, not what\n" +
+		"succeeded: a line may have failed, been a typo, or targeted something that\n" +
+		"no longer exists. And repeated commands are collapsed to their most recent\n" +
+		"occurrence, and the file is capped at a configured limit, so it is not a\n" +
+		"chronological log and says nothing about how often a command is used.\n\n" +
+		"Empty output is not an error - a project can configure history off, in\n" +
+		"which case nothing is ever recorded."
+}
+
 func (c *History) Execute(ctx context.Context, r *readline.Readline) error {
 	value, err := c.history.Load(ctx)
 	if err != nil {

--- a/pkg/command/payload.go
+++ b/pkg/command/payload.go
@@ -1,0 +1,55 @@
+package command
+
+// Payload types for agent mode. They are exported so a provider embedding these
+// commands - or writing its own against the same shapes - can unmarshal the
+// output rather than re-deriving the JSON structure from a struct literal.
+//
+// Results are emitted bare, without a type/schema_version envelope: a caller
+// invoked a specific command and already knows what it asked for. Log lines
+// written by pkg/log.AgentJSON keep their "type" discriminator, which is what
+// lets a consumer tell an interleaved log line from the result value.
+
+// EnvVar is a single environment variable. Value is omitted unless the listing
+// was requested with values.
+type EnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
+}
+
+// EnvList is the result of `env list`.
+type EnvList struct {
+	Values []EnvVar `json:"values"`
+}
+
+// EnvGet is the result of `env get`.
+type EnvGet struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// CacheNamespace is a single cache namespace and the keys it holds. Values are
+// deliberately excluded - use `cache get` to read one.
+type CacheNamespace struct {
+	Namespace string   `json:"namespace"`
+	Keys      []string `json:"keys"`
+}
+
+// CacheList is the result of `cache list`.
+type CacheList struct {
+	Namespaces []CacheNamespace `json:"namespaces"`
+}
+
+// CacheGet is the result of `cache get`. Value is nil when the key is unset.
+type CacheGet struct {
+	Namespace string `json:"namespace"`
+	Key       string `json:"key"`
+	Value     any    `json:"value"`
+}
+
+// Version is the result of `posh version`. Commit and BuildTime are only
+// populated at debug level, matching the fields the human output prints there.
+type Version struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit,omitempty"`
+	BuildTime string `json:"build_time,omitempty"`
+}

--- a/pkg/command/skill.go
+++ b/pkg/command/skill.go
@@ -1,0 +1,37 @@
+package command
+
+import (
+	"context"
+)
+
+// Skiller is an optional Command extension: a command that contributes extra
+// markdown to the generated SKILL.md, beyond the structure Describer already
+// provides - extended instructions, worked configuration examples, links to
+// further docs.
+//
+// The contract is deliberately a free-form string rather than a struct: what is
+// worth telling an agent varies per command, and a fixed shape would constrain
+// that without buying anything, since the destination is markdown either way.
+//
+// The returned markdown is appended verbatim under the command's heading in
+// SKILL.md, after its arguments, flags and subcommands. Use heading level 4
+// (####) or deeper - level 3 is the command heading itself.
+//
+// Commands that do not implement it render exactly as they did before.
+type Skiller interface {
+	Skill(ctx context.Context) string
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Public methods
+// ------------------------------------------------------------------------------------------------
+
+// Skill returns the extra SKILL.md markdown v contributes, or an empty string if
+// it does not implement Skiller.
+func Skill(ctx context.Context, v any) string {
+	if s, ok := v.(Skiller); ok {
+		return s.Skill(ctx)
+	}
+
+	return ""
+}

--- a/pkg/command/skill_test.go
+++ b/pkg/command/skill_test.go
@@ -1,0 +1,73 @@
+package command_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/foomo/posh/pkg/cache"
+	"github.com/foomo/posh/pkg/command"
+	"github.com/foomo/posh/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// skiller is a command contributing extra SKILL.md markdown.
+type skiller struct{ leaf }
+
+func (skiller) Skill(ctx context.Context) string { return "#### Notes\n\nRun it twice." }
+
+// TestSkill_NotASkiller covers the fallback: a command that does not opt in
+// contributes nothing.
+func TestSkill_NotASkiller(t *testing.T) {
+	assert.Empty(t, command.Skill(t.Context(), leaf{}))
+}
+
+// TestSkill_Skiller covers the dispatch.
+func TestSkill_Skiller(t *testing.T) {
+	assert.Equal(t, "#### Notes\n\nRun it twice.", command.Skill(t.Context(), skiller{}))
+}
+
+// TestSkill_BuiltIns asserts every built-in command contributes prose, and that
+// each contribution is renderable: a "###" heading would collide with the
+// command heading RenderSkill puts above it.
+func TestSkill_BuiltIns(t *testing.T) {
+	l := log.NewTest(t)
+
+	for name, cmd := range map[string]any{
+		"cache":   command.NewCache(l, cache.NewMemoryCache()),
+		"check":   command.NewCheck(l),
+		"env":     command.NewEnv(l),
+		"exit":    command.NewExit(l),
+		"help":    command.NewHelp(l, command.Commands{}),
+		"history": command.NewHistory(l, nil),
+	} {
+		t.Run(name, func(t *testing.T) {
+			actual := command.Skill(t.Context(), cmd)
+
+			require.NotEmpty(t, actual, "every built-in should contribute skill prose")
+			assert.True(t, strings.HasPrefix(actual, "#### "),
+				"contributions must start at heading level 4, below the command's own")
+
+			for line := range strings.SplitSeq(actual, "\n") {
+				assert.False(t, strings.HasPrefix(line, "### ") || strings.HasPrefix(line, "## "),
+					"a heading above level 4 would collide with the command heading: %q", line)
+			}
+		})
+	}
+}
+
+// TestDescribe_Help covers the hand-built CommandInfo: help is not tree based,
+// so without it the optional [command] argument would be invisible.
+func TestDescribe_Help(t *testing.T) {
+	actual := command.NewHelp(log.NewTest(t), command.Commands{}).Describe(t.Context())
+
+	assert.Equal(t, "help", actual.FullPath)
+
+	require.Len(t, actual.Arguments, 1)
+	assert.Equal(t, "command", actual.Arguments[0].Name)
+	assert.True(t, actual.Arguments[0].Optional)
+
+	// Usage is rebuilt from the arguments, so an optional one is angled.
+	assert.Equal(t, "<command>", actual.Usage())
+}

--- a/pkg/command/tree/describe.go
+++ b/pkg/command/tree/describe.go
@@ -1,0 +1,154 @@
+package tree
+
+import (
+	"context"
+	"strings"
+
+	"github.com/foomo/posh/pkg/readline"
+	"github.com/foomo/posh/pkg/util"
+	"github.com/spf13/pflag"
+)
+
+// CommandInfo describes one command for the `posh agent catalog` catalog. It
+// mirrors the shape used by other agent-facing CLIs, so a consumer that can
+// read one catalog can read this one.
+type CommandInfo struct {
+	// FullPath is the command as typed, e.g. "cache clear".
+	FullPath    string `json:"full_path"`
+	Description string `json:"description"`
+	// Dynamic marks a node whose name is resolved at runtime (a cluster name,
+	// a cache key, ...). Its FullPath carries a "<placeholder>" instead of a
+	// literal name - run the command to discover the actual values.
+	Dynamic     bool          `json:"dynamic,omitempty"`
+	Arguments   []ArgInfo     `json:"arguments,omitempty"`
+	Flags       []FlagInfo    `json:"flags,omitempty"`
+	Subcommands []CommandInfo `json:"subcommands,omitempty"`
+}
+
+// ArgInfo describes a single positional argument of a command, in the order it
+// is expected on the command line.
+type ArgInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Optional    bool   `json:"optional,omitempty"`
+	// Repeat marks an argument that may be given more than once. Only the last
+	// argument of a command can repeat.
+	Repeat bool `json:"repeat,omitempty"`
+}
+
+// FlagInfo describes a single flag of a command.
+type FlagInfo struct {
+	Name        string `json:"name"`
+	Shorthand   string `json:"shorthand,omitempty"`
+	Type        string `json:"type"`
+	Default     string `json:"default"`
+	Description string `json:"description"`
+}
+
+// Usage renders the arguments as a usage string, e.g. "[Key] <Value>...",
+// where required arguments are bracketed, optional ones angled and a
+// repeatable argument is suffixed with "...".
+func (c CommandInfo) Usage() string {
+	var ret strings.Builder
+
+	for i, arg := range c.Arguments {
+		if i > 0 {
+			ret.WriteString(" ")
+		}
+
+		if arg.Optional {
+			ret.WriteString("<" + arg.Name + ">")
+		} else {
+			ret.WriteString("[" + arg.Name + "]")
+		}
+
+		if arg.Repeat {
+			ret.WriteString("...")
+		}
+	}
+
+	return ret.String()
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Private methods
+// ------------------------------------------------------------------------------------------------
+
+// describe recursively describes a node and its children, accumulating the
+// command path as it descends.
+func (c *Node) describe(ctx context.Context, r *readline.Readline, prefix string) CommandInfo {
+	name := c.Name
+	if c.Values != nil {
+		if name == "" {
+			name = "value"
+		}
+
+		name = "<" + name + ">"
+	}
+
+	fullPath := util.Pick(prefix != "", prefix+" "+name, name)
+
+	ret := CommandInfo{
+		FullPath:    fullPath,
+		Description: c.Description,
+		Dynamic:     c.Values != nil,
+		Arguments:   c.Args.describe(),
+		Flags:       c.describeFlags(ctx, r),
+	}
+
+	for _, value := range c.Nodes {
+		ret.Subcommands = append(ret.Subcommands, value.describe(ctx, r, fullPath))
+	}
+
+	return ret
+}
+
+// describe describes the positional arguments, preserving the order they are
+// expected in.
+func (a Args) describe() []ArgInfo {
+	if len(a) == 0 {
+		return nil
+	}
+
+	ret := make([]ArgInfo, 0, len(a))
+	for _, arg := range a {
+		ret = append(ret, ArgInfo{
+			Name:        arg.Name,
+			Description: arg.Description,
+			Optional:    arg.Optional,
+			Repeat:      arg.Repeat,
+		})
+	}
+
+	return ret
+}
+
+// describeFlags enumerates a node's flag definitions. Flags are best effort: a
+// node whose Flags callback fails is listed without them rather than failing
+// the whole catalog.
+func (c *Node) describeFlags(ctx context.Context, r *readline.Readline) []FlagInfo {
+	if c.Flags == nil {
+		return nil
+	}
+
+	fs := readline.NewFlagSets()
+	if err := c.Flags(ctx, r, fs); err != nil {
+		return nil
+	}
+
+	var ret []FlagInfo
+
+	// All merges every set into one pflag.FlagSet, whose VisitAll sorts by
+	// name - so the order the sets were populated in does not leak out here.
+	fs.All().VisitAll(func(f *pflag.Flag) {
+		ret = append(ret, FlagInfo{
+			Name:        f.Name,
+			Shorthand:   f.Shorthand,
+			Type:        f.Value.Type(),
+			Default:     f.DefValue,
+			Description: f.Usage,
+		})
+	})
+
+	return ret
+}

--- a/pkg/command/tree/describe_test.go
+++ b/pkg/command/tree/describe_test.go
@@ -1,0 +1,236 @@
+package tree_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/foomo/posh/pkg/command/tree"
+	"github.com/foomo/posh/pkg/prompt/goprompt"
+	"github.com/foomo/posh/pkg/readline"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribe_NilNode(t *testing.T) {
+	assert.Empty(t, tree.New(nil).Describe(t.Context()))
+}
+
+func TestDescribe_Nested(t *testing.T) {
+	actual := tree.New(&tree.Node{
+		Name:        "cache",
+		Description: "Manage the internal cache",
+		Nodes: tree.Nodes{
+			{
+				Name:        "clear",
+				Description: "Clear caches",
+				Args: tree.Args{
+					{
+						Name:        "Namespace",
+						Description: "Name of namespace to clear.",
+						Optional:    true,
+						Repeat:      true,
+					},
+				},
+			},
+			{
+				Name:        "list",
+				Description: "List all caches",
+			},
+		},
+	}).Describe(t.Context())
+
+	assert.Equal(t, "cache", actual.FullPath)
+	assert.Equal(t, "Manage the internal cache", actual.Description)
+
+	require.Len(t, actual.Subcommands, 2)
+
+	clearCmd := actual.Subcommands[0]
+	assert.Equal(t, "cache clear", clearCmd.FullPath)
+	assert.Equal(t, "Clear caches", clearCmd.Description)
+
+	require.Len(t, clearCmd.Arguments, 1)
+	assert.Equal(t, tree.ArgInfo{
+		Name:        "Namespace",
+		Description: "Name of namespace to clear.",
+		Optional:    true,
+		Repeat:      true,
+	}, clearCmd.Arguments[0])
+	assert.Equal(t, "<Namespace>...", clearCmd.Usage())
+
+	assert.Equal(t, "cache list", actual.Subcommands[1].FullPath)
+	assert.Empty(t, actual.Subcommands[1].Arguments)
+	assert.Empty(t, actual.Subcommands[1].Usage())
+}
+
+func TestDescribe_NestedDepth(t *testing.T) {
+	actual := tree.New(&tree.Node{
+		Name: "a",
+		Nodes: tree.Nodes{
+			{
+				Name:  "b",
+				Nodes: tree.Nodes{{Name: "c"}},
+			},
+		},
+	}).Describe(t.Context())
+
+	require.Len(t, actual.Subcommands, 1)
+	require.Len(t, actual.Subcommands[0].Subcommands, 1)
+	assert.Equal(t, "a b c", actual.Subcommands[0].Subcommands[0].FullPath)
+}
+
+func TestDescribe_Args(t *testing.T) {
+	actual := tree.New(&tree.Node{
+		Name: "run",
+		Args: tree.Args{
+			{Name: "Cluster", Description: "the target cluster"},
+			{Name: "Target", Optional: true},
+		},
+	}).Describe(t.Context())
+
+	// Order is significant: arguments are positional.
+	require.Len(t, actual.Arguments, 2)
+	assert.Equal(t, "Cluster", actual.Arguments[0].Name)
+	assert.Equal(t, "the target cluster", actual.Arguments[0].Description)
+	assert.False(t, actual.Arguments[0].Optional)
+	assert.False(t, actual.Arguments[0].Repeat)
+
+	assert.Equal(t, "Target", actual.Arguments[1].Name)
+	assert.Empty(t, actual.Arguments[1].Description)
+	assert.True(t, actual.Arguments[1].Optional)
+
+	assert.Equal(t, "[Cluster] <Target>", actual.Usage())
+}
+
+func TestCommandInfo_Usage(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []tree.ArgInfo
+		expected string
+	}{
+		{
+			name:     "none",
+			expected: "",
+		},
+		{
+			name:     "required",
+			args:     []tree.ArgInfo{{Name: "Key"}},
+			expected: "[Key]",
+		},
+		{
+			name:     "optional repeat",
+			args:     []tree.ArgInfo{{Name: "Namespace", Optional: true, Repeat: true}},
+			expected: "<Namespace>...",
+		},
+		{
+			name:     "mixed",
+			args:     []tree.ArgInfo{{Name: "Key"}, {Name: "Value", Optional: true}},
+			expected: "[Key] <Value>",
+		},
+		{
+			name:     "required repeat",
+			args:     []tree.ArgInfo{{Name: "Path", Repeat: true}},
+			expected: "[Path]...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tree.CommandInfo{Arguments: tt.args}.Usage())
+		})
+	}
+}
+
+// TestDescribe_FlagsSorted pins the ordering guarantee callers rely on:
+// flags come out sorted by name regardless of which set they were registered
+// in or in what order. This holds because FlagSets.All merges everything into
+// one pflag.FlagSet whose VisitAll sorts - the test exists so that stops being
+// an implementation detail nobody notices changing.
+func TestDescribe_FlagsSorted(t *testing.T) {
+	names := []string{"zeta", "yankee", "xray", "whiskey", "victor", "uniform", "tango", "sierra"}
+
+	actual := tree.New(&tree.Node{
+		Name: "run",
+		Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+			// Registered in reverse alphabetical order, alternating sets.
+			for i, name := range names {
+				if i%2 == 0 {
+					fs.Default().String(name, "", name+" flag")
+				} else {
+					fs.Internal().String(name, "", name+" flag")
+				}
+			}
+
+			return nil
+		},
+	}).Describe(t.Context())
+
+	require.Len(t, actual.Flags, len(names))
+	assert.True(t, sort.SliceIsSorted(actual.Flags, func(i, j int) bool {
+		return actual.Flags[i].Name < actual.Flags[j].Name
+	}), "flags must be sorted by name, got %v", actual.Flags)
+	assert.Equal(t, "sierra", actual.Flags[0].Name)
+	assert.Equal(t, "zeta", actual.Flags[len(names)-1].Name)
+}
+
+func TestDescribe_FlagFields(t *testing.T) {
+	actual := tree.New(&tree.Node{
+		Name: "run",
+		Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+			fs.Default().StringP("mid", "m", "fallback", "mid flag")
+			fs.Default().Bool("dry-run", false, "dry run flag")
+
+			return nil
+		},
+	}).Describe(t.Context())
+
+	require.Len(t, actual.Flags, 2)
+
+	assert.Equal(t, "dry-run", actual.Flags[0].Name)
+	assert.Equal(t, "bool", actual.Flags[0].Type)
+	assert.Equal(t, "false", actual.Flags[0].Default)
+	assert.Empty(t, actual.Flags[0].Shorthand)
+
+	assert.Equal(t, "mid", actual.Flags[1].Name)
+	assert.Equal(t, "m", actual.Flags[1].Shorthand)
+	assert.Equal(t, "string", actual.Flags[1].Type)
+	assert.Equal(t, "fallback", actual.Flags[1].Default)
+	assert.Equal(t, "mid flag", actual.Flags[1].Description)
+}
+
+func TestDescribe_FlagsError(t *testing.T) {
+	actual := tree.New(&tree.Node{
+		Name:        "run",
+		Description: "run it",
+		Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+			return errors.New("nope")
+		},
+	}).Describe(t.Context())
+
+	assert.Equal(t, "run", actual.FullPath)
+	assert.Equal(t, "run it", actual.Description)
+	assert.Empty(t, actual.Flags)
+}
+
+// TestDescribe_Dynamic asserts the walk never invokes a Values callback: doing
+// so would resolve live state (kubeconfig, cloud APIs) at catalog time.
+func TestDescribe_Dynamic(t *testing.T) {
+	actual := tree.New(&tree.Node{
+		Name: "kubectl",
+		Nodes: tree.Nodes{
+			{
+				Name:        "cluster",
+				Description: "target cluster",
+				Values: func(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
+					panic("Values must not be invoked while building the catalog")
+				},
+			},
+		},
+	}).Describe(t.Context())
+
+	require.Len(t, actual.Subcommands, 1)
+	assert.Equal(t, "kubectl <cluster>", actual.Subcommands[0].FullPath)
+	assert.True(t, actual.Subcommands[0].Dynamic)
+	assert.False(t, actual.Dynamic)
+}

--- a/pkg/command/tree/help_test.go
+++ b/pkg/command/tree/help_test.go
@@ -79,7 +79,7 @@ func TestRoot_Help(t *testing.T) {
 			contains: []string{"Flags:", "--foo", "foo desc"},
 		},
 		{
-			name: "leaf with flags callback error omits Flags section",
+			name: "leaf with flags callback error surfaces the error in Flags section",
 			root: tree.New(&tree.Node{
 				Name:        "root",
 				Description: "root desc",
@@ -87,9 +87,8 @@ func TestRoot_Help(t *testing.T) {
 					return errBoom
 				},
 			}),
-			input:       "root self",
-			contains:    []string{"Usage:", "root"},
-			notContains: []string{"Flags:"},
+			input:    "root self",
+			contains: []string{"Usage:", "root", "Flags:", "error:", "boom"},
 		},
 		{
 			name: "descends to matched child",

--- a/pkg/command/tree/node.go
+++ b/pkg/command/tree/node.go
@@ -193,7 +193,9 @@ func (c *Node) help(ctx context.Context, r *readline.Readline) string {
 
 		if c.Flags != nil {
 			fs := readline.NewFlagSets()
-			if err := c.Flags(ctx, r, fs); err == nil {
+			if err := c.Flags(ctx, r, fs); err != nil {
+				ret.WriteString("\n\nFlags:\n" + pad + "error: " + err.Error() + "\n")
+			} else {
 				ret.WriteString("\n\nFlags:\n")
 				ret.WriteString(fs.All().FlagUsages())
 			}

--- a/pkg/command/tree/root.go
+++ b/pkg/command/tree/root.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"sort"
 
+	"github.com/foomo/posh/pkg/log"
 	"github.com/foomo/posh/pkg/prompt/goprompt"
 	"github.com/foomo/posh/pkg/readline"
 )
 
 type Root interface {
 	Node() *Node
+	Describe(ctx context.Context) CommandInfo
 	Complete(ctx context.Context, r *readline.Readline) []goprompt.Suggest
 	Execute(ctx context.Context, r *readline.Readline) error
 	Help(ctx context.Context, r *readline.Readline) string
@@ -138,4 +140,30 @@ func (t *root) Help(ctx context.Context, r *readline.Readline) string {
 	}
 
 	return cmd.help(ctx, r)
+}
+
+// Describe walks the whole tree into a CommandInfo - subcommands, arguments and
+// flags - for `posh agent catalog`. It is the one-line implementation of the
+// optional command.Describer interface for a tree based command:
+//
+//	func (c *Cache) Describe(ctx context.Context) tree.CommandInfo {
+//		return c.tree.Describe(ctx)
+//	}
+//
+// The walk is deliberately offline: a node's Values callback resolves dynamic
+// names against live state (kubeconfig, cloud APIs, the cache), so it is never
+// invoked. Such nodes are emitted as a placeholder with Dynamic set.
+func (t *root) Describe(ctx context.Context) CommandInfo {
+	if t.node == nil {
+		return CommandInfo{}
+	}
+
+	// Flags are enumerated, never parsed, so the readline only needs to exist:
+	// it requires no terminal, never logs, and is shared across the subtree.
+	r, err := readline.New(log.NewFmt())
+	if err != nil {
+		return CommandInfo{FullPath: t.node.Name, Description: t.node.Description}
+	}
+
+	return t.node.describe(ctx, r, "")
 }

--- a/pkg/log/agentjson.go
+++ b/pkg/log/agentjson.go
@@ -1,0 +1,212 @@
+package log
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// AgentJSON is a Logger implementation that writes one JSON object per line
+// (JSONL) to stdout instead of PTerm's human-formatted, colored output. It is
+// selected in agent mode (see pkg/agent) so an AI coding agent driving
+// `posh execute` gets machine-parseable output instead of prose.
+//
+// Every entry carries a fixed "type"/"schema_version" discriminator so
+// consumers can dispatch on a marker rather than guessing from shape.
+type (
+	AgentJSON struct {
+		name  string
+		level Level
+		w     io.Writer
+		out   *json.Encoder
+	}
+	AgentJSONOption func(*AgentJSON)
+)
+
+type agentLogEntry struct {
+	Type          string `json:"type"`
+	SchemaVersion string `json:"schema_version"`
+	Level         string `json:"level"`
+	Name          string `json:"name,omitempty"`
+	Message       string `json:"message"`
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Options
+// ------------------------------------------------------------------------------------------------
+
+func AgentJSONWithWriter(w io.Writer) AgentJSONOption {
+	return func(o *AgentJSON) {
+		o.w = w
+	}
+}
+
+func AgentJSONWithLevel(v Level) AgentJSONOption {
+	return func(o *AgentJSON) {
+		o.level = v
+	}
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Constructor
+// ------------------------------------------------------------------------------------------------
+
+func NewAgentJSON(opts ...AgentJSONOption) *AgentJSON {
+	inst := &AgentJSON{
+		level: LevelInfo,
+		w:     os.Stdout,
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			opt(inst)
+		}
+	}
+
+	enc := json.NewEncoder(inst.w)
+	enc.SetEscapeHTML(false)
+	inst.out = enc
+
+	return inst
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Public methods
+// ------------------------------------------------------------------------------------------------
+
+func (l *AgentJSON) Level() Level {
+	return l.level
+}
+
+func (l *AgentJSON) IsLevel(v Level) bool {
+	return l.level <= v
+}
+
+func (l *AgentJSON) Named(name string) Logger {
+	clone := *l
+	clone.name = name
+
+	return &clone
+}
+
+func (l *AgentJSON) Print(a ...any) {
+	l.write("info", sprintSpaced(a))
+}
+
+func (l *AgentJSON) Printf(format string, a ...any) {
+	l.write("info", fmt.Sprintf(format, a...))
+}
+
+func (l *AgentJSON) Success(a ...any) {
+	l.write("success", sprintSpaced(a))
+}
+
+func (l *AgentJSON) Successf(format string, a ...any) {
+	l.write("success", fmt.Sprintf(format, a...))
+}
+
+func (l *AgentJSON) Trace(a ...any) {
+	if l.IsLevel(LevelTrace) {
+		l.write("trace", sprintSpaced(a))
+	}
+}
+
+func (l *AgentJSON) Tracef(format string, a ...any) {
+	if l.IsLevel(LevelTrace) {
+		l.write("trace", fmt.Sprintf(format, a...))
+	}
+}
+
+func (l *AgentJSON) Debug(a ...any) {
+	if l.IsLevel(LevelDebug) {
+		l.write("debug", sprintSpaced(a))
+	}
+}
+
+func (l *AgentJSON) Debugf(format string, a ...any) {
+	if l.IsLevel(LevelDebug) {
+		l.write("debug", fmt.Sprintf(format, a...))
+	}
+}
+
+func (l *AgentJSON) Info(a ...any) {
+	if l.IsLevel(LevelInfo) {
+		l.write("info", sprintSpaced(a))
+	}
+}
+
+func (l *AgentJSON) Infof(format string, a ...any) {
+	if l.IsLevel(LevelInfo) {
+		l.write("info", fmt.Sprintf(format, a...))
+	}
+}
+
+func (l *AgentJSON) Warn(a ...any) {
+	if l.IsLevel(LevelWarn) {
+		l.write("warn", sprintSpaced(a))
+	}
+}
+
+func (l *AgentJSON) Warnf(format string, a ...any) {
+	if l.IsLevel(LevelWarn) {
+		l.write("warn", fmt.Sprintf(format, a...))
+	}
+}
+
+func (l *AgentJSON) Error(a ...any) {
+	if l.IsLevel(LevelError) {
+		l.write("error", sprintSpaced(a))
+	}
+}
+
+func (l *AgentJSON) Errorf(format string, a ...any) {
+	if l.IsLevel(LevelError) {
+		l.write("error", fmt.Sprintf(format, a...))
+	}
+}
+
+func (l *AgentJSON) Fatal(a ...any) {
+	l.write("fatal", sprintSpaced(a))
+	os.Exit(1)
+}
+
+func (l *AgentJSON) Fatalf(format string, a ...any) {
+	l.write("fatal", fmt.Sprintf(format, a...))
+	os.Exit(1)
+}
+
+func (l *AgentJSON) Must(err error) {
+	if err != nil {
+		l.Fatal(err.Error())
+	}
+}
+
+func (l *AgentJSON) SlogHandler() slog.Handler {
+	return slog.NewJSONHandler(l.w, nil)
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Private methods
+// ------------------------------------------------------------------------------------------------
+
+// sprintSpaced joins a like fmt.Println does (always space-separated),
+// matching PTerm's Print/Info/etc. behavior (which delegates to
+// pterm.Println), unlike fmt.Sprint which only spaces non-string operands.
+func sprintSpaced(a []any) string {
+	return strings.TrimSuffix(fmt.Sprintln(a...), "\n")
+}
+
+func (l *AgentJSON) write(level, message string) {
+	if err := l.out.Encode(agentLogEntry{
+		Type:          "posh.log",
+		SchemaVersion: "1",
+		Level:         level,
+		Name:          l.name,
+		Message:       message,
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+}

--- a/pkg/log/agentjson_test.go
+++ b/pkg/log/agentjson_test.go
@@ -1,0 +1,58 @@
+package log_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/foomo/posh/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentJSON_Info(t *testing.T) {
+	var buf bytes.Buffer
+
+	l := log.NewAgentJSON(log.AgentJSONWithWriter(&buf))
+
+	l.Info("hello", "world")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 1)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &entry))
+
+	assert.Equal(t, "posh.log", entry["type"])
+	assert.Equal(t, "1", entry["schema_version"])
+	assert.Equal(t, "info", entry["level"])
+	assert.Equal(t, "hello world", entry["message"])
+}
+
+func TestAgentJSON_LevelGating(t *testing.T) {
+	var buf bytes.Buffer
+
+	l := log.NewAgentJSON(log.AgentJSONWithWriter(&buf), log.AgentJSONWithLevel(log.LevelWarn))
+
+	l.Info("suppressed")
+	l.Warn("kept")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 1)
+	assert.Contains(t, lines[0], "kept")
+}
+
+func TestAgentJSON_EachLineIsValidJSON(t *testing.T) {
+	var buf bytes.Buffer
+
+	l := log.NewAgentJSON(log.AgentJSONWithWriter(&buf))
+
+	l.Info("first")
+	l.Error("second")
+
+	for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
+		var entry map[string]any
+		assert.NoError(t, json.Unmarshal([]byte(line), &entry))
+	}
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	ownbrewconfig "github.com/foomo/ownbrew/pkg/config"
+	"github.com/foomo/posh/pkg/command"
 	"github.com/foomo/posh/pkg/config"
 )
 
@@ -19,4 +20,79 @@ type Plugin interface {
 // "value\tdescription" (description optional).
 type Completer interface {
 	Complete(ctx context.Context, args []string, toComplete string) []string
+}
+
+// Lister is an optional Plugin extension that exposes the catalog of
+// commands, used by `posh agent catalog` to give an AI coding agent a
+// machine-readable answer to "what can I run" without parsing human-formatted
+// help text.
+type Lister interface {
+	List(ctx context.Context) []CommandInfo
+}
+
+// SkillLister is an optional Plugin extension that lists commands together with
+// the extra SKILL.md markdown each one contributes via command.Skiller.
+//
+// A plugin implementing only Lister still renders a skill, just without the
+// extra prose.
+type SkillLister interface {
+	ListSkill(ctx context.Context) []SkillCommand
+}
+
+// SkillMetadataer is an optional Plugin extension supplying the generated
+// SKILL.md frontmatter. Unset fields fall back to posh's defaults.
+type SkillMetadataer interface {
+	SkillMetadata(ctx context.Context) SkillMetadata
+}
+
+// Catalog is the payload of `posh agent catalog`.
+//
+// Unlike command results, which are emitted bare, the catalog keeps its
+// type/schema_version discriminator: the shape is a published contract mirroring
+// other agent-facing CLIs, and consumers dispatch on the marker.
+type Catalog struct {
+	Type          string        `json:"type"`
+	SchemaVersion string        `json:"schema_version"`
+	Commands      []CommandInfo `json:"commands"`
+}
+
+// CatalogType is the discriminator carried by Catalog.
+const CatalogType = "posh.command_catalog"
+
+// CatalogSchemaVersion is the current version of the Catalog shape.
+const CatalogSchemaVersion = "3"
+
+// NewCatalog wraps commands in a Catalog with the current type and version.
+func NewCatalog(commands []CommandInfo) Catalog {
+	return Catalog{
+		Type:          CatalogType,
+		SchemaVersion: CatalogSchemaVersion,
+		Commands:      commands,
+	}
+}
+
+// The catalog shapes live in pkg/command, next to the Command interface they
+// describe, and are aliased here so a plugin does not need to import both.
+type (
+	// CommandInfo describes one command for the `posh agent catalog` catalog.
+	CommandInfo = command.CommandInfo
+	// ArgInfo describes a single positional argument of a command.
+	ArgInfo = command.ArgInfo
+	// FlagInfo describes a single flag of a command.
+	FlagInfo = command.FlagInfo
+)
+
+// ------------------------------------------------------------------------------------------------
+// ~ Public methods
+// ------------------------------------------------------------------------------------------------
+
+// Describe builds a CommandInfo for a single command, see command.Describe.
+func Describe(ctx context.Context, name, description string, v any) CommandInfo {
+	return command.Describe(ctx, name, description, v)
+}
+
+// Skill returns the extra SKILL.md markdown a command contributes, see
+// command.Skill.
+func Skill(ctx context.Context, v any) string {
+	return command.Skill(ctx, v)
 }

--- a/pkg/plugin/skill.go
+++ b/pkg/plugin/skill.go
@@ -1,0 +1,225 @@
+package plugin
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/foomo/posh/pkg/util"
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultSkillPath is where `posh agent skill install` writes the skill unless
+// given an explicit path.
+const DefaultSkillPath = ".claude/skills/posh/SKILL.md"
+
+// Defaults for the generated frontmatter, used for any SkillMetadata field a
+// project leaves unset.
+const (
+	defaultSkillName        = "posh"
+	defaultSkillDescription = "Drive this project's posh shell (Project Oriented Shell)."
+)
+
+// skillSetup documents posh's own subcommands, as opposed to the project
+// commands the catalog below is generated from.
+//
+// It is a fixed string rather than a walk of the cobra tree: these commands are
+// the same in every project, they are wired up in cmd/ - which imports this
+// package, so the dependency cannot go the other way - and an agent mostly
+// needs them when `posh execute` fails because the environment is not set up.
+const skillSetup = "## Setup\n\n" +
+	"All of it is configured in this project's `.posh.yaml`; read that file to see\n" +
+	"what is actually required or installed before running anything below.\n\n" +
+	"- `posh require` - validate the preconditions from the `require` key (env\n" +
+	"  vars, packages, scripts). Run it first when a command fails unexpectedly.\n" +
+	"- `posh brew` - install the pinned tool versions from the `ownbrew` key. Run\n" +
+	"  it when `posh require` reports a missing package; `--dry` only prints what\n" +
+	"  would be installed.\n" +
+	"- `posh prompt` - the interactive shell, configured by the `prompt` key. Do\n" +
+	"  not run it under an agent harness: it blocks waiting on a TTY. Use\n" +
+	"  `posh execute` for individual commands instead.\n\n"
+
+// SkillCommand pairs a described command with the extra markdown its
+// command.Skiller implementation contributed, if any.
+//
+// The catalog shape stays untouched: skill prose is a rendering concern, so it
+// rides alongside CommandInfo rather than inside it.
+type SkillCommand struct {
+	CommandInfo
+
+	// Skill is the markdown contributed by command.Skiller, or empty.
+	Skill string
+}
+
+// SkillMetadata is the SKILL.md frontmatter a project can override.
+//
+// The fields are restricted to the Agent Skills spec allowlist
+// (https://agentskills.io) so the generated skill stays valid if it is ever
+// uploaded to claude.ai or the Skills API, both of which reject unknown keys.
+type SkillMetadata struct {
+	// Name defaults to "posh".
+	Name string `yaml:"name"`
+	// Description defaults to a generic one. A project specific description is
+	// what makes the skill trigger on this project's vocabulary.
+	Description string `yaml:"description"`
+	// AllowedTools are granted without a permission prompt for the turn that
+	// invokes the skill, e.g. "Bash(posh execute:*)".
+	AllowedTools []string `yaml:"allowed-tools,omitempty"`
+}
+
+// RenderSkill renders a Claude Code SKILL.md from a command catalog.
+//
+// The result is generated in full from the catalog every time, so it always
+// reflects whatever commands a project's posh shell currently registers - there
+// is no hand-maintained content to drift out of sync. A zero SkillMetadata
+// renders posh's default frontmatter.
+func RenderSkill(meta SkillMetadata, commands []SkillCommand) string {
+	var b strings.Builder
+
+	writeSkillFrontmatter(&b, meta)
+
+	b.WriteString("# posh\n\n")
+	b.WriteString("Run project tasks via `posh execute <command...>` (alias `posh x`) instead of\n")
+	b.WriteString("guessing shell commands directly. JSON output is automatic under an agent\n")
+	b.WriteString("harness; `POSH_AGENT_MODE=0` forces human output. Re-run\n")
+	b.WriteString("`posh agent skill update` after this project's commands change to refresh\n")
+	b.WriteString("this file.\n\n")
+	b.WriteString("posh does not enforce access control: whatever the surrounding harness or CI\n")
+	b.WriteString("permits is the real boundary. A command being listed here does not mean it is\n")
+	b.WriteString("safe to run unattended.\n\n")
+	b.WriteString(skillSetup)
+	b.WriteString("## Commands\n\n")
+	b.WriteString("Only commands with more to say than their one-line description appear below.\n")
+	b.WriteString("This is not the full list - run `posh agent catalog` for every command as\n")
+	b.WriteString("JSON, or `posh help` for the human-readable list.\n\n")
+
+	for _, c := range commands {
+		if !c.describes() {
+			continue
+		}
+
+		heading := c.FullPath
+		if usage := c.Usage(); usage != "" {
+			heading += " " + usage
+		}
+
+		fmt.Fprintf(&b, "### `%s`\n\n%s\n\n", heading, c.Description)
+
+		// Arguments, flags and subcommands share one heading: without it the
+		// list runs straight on from the description, while the command's own
+		// Skiller prose below does carry a heading - so the structure reads as
+		// part of the description.
+		if len(c.Arguments) > 0 || len(c.Flags) > 0 || len(c.Subcommands) > 0 {
+			b.WriteString("#### Usage\n\n")
+		}
+
+		writeSkillDetails(&b, c.CommandInfo, "")
+
+		if len(c.Arguments) > 0 || len(c.Flags) > 0 {
+			b.WriteString("\n")
+		}
+
+		writeSkillSubcommands(&b, c.Subcommands, 0)
+
+		// Trimmed so a contribution ending in a newline does not stack blank
+		// lines on top of the one added here.
+		if skill := strings.TrimSpace(c.Skill); skill != "" {
+			b.WriteString(skill + "\n\n")
+		}
+	}
+
+	return b.String()
+}
+
+// describes reports whether a command says anything the skill is worth spending
+// tokens on: prose from command.Skiller, or structure from command.Describer.
+//
+// The test is deliberately structural rather than "does it implement the
+// interfaces". command.Describe already collapses a non-Describer into a
+// CommandInfo carrying only a path and description, so by the time it arrives
+// here a command that never opted in is indistinguishable from a Describer that
+// legitimately describes a bare leaf - and both are equally uninformative. An
+// agent reading the catalog has the name and description either way.
+func (c SkillCommand) describes() bool {
+	return strings.TrimSpace(c.Skill) != "" ||
+		len(c.Arguments) > 0 ||
+		len(c.Flags) > 0 ||
+		len(c.Subcommands) > 0
+}
+
+// writeSkillFrontmatter renders the YAML frontmatter, falling back to posh's
+// defaults for unset fields.
+//
+// The values are marshalled rather than concatenated: a description containing
+// a colon - or starting with a "#" - would otherwise produce invalid YAML.
+func writeSkillFrontmatter(b *strings.Builder, meta SkillMetadata) {
+	if meta.Name == "" {
+		meta.Name = defaultSkillName
+	}
+
+	if meta.Description == "" {
+		meta.Description = defaultSkillDescription
+	}
+
+	b.WriteString("---\n")
+
+	// Marshal cannot fail for a struct of strings, so a failure here leaves the
+	// frontmatter empty rather than taking the whole skill down.
+	if out, err := yaml.Marshal(meta); err == nil {
+		b.Write(out)
+	}
+
+	b.WriteString("---\n\n")
+}
+
+// writeSkillDetails renders a command's arguments and flags as an indented list.
+func writeSkillDetails(b *strings.Builder, c CommandInfo, pad string) {
+	for _, a := range c.Arguments {
+		name := util.Pick(a.Optional, "<"+a.Name+">", "["+a.Name+"]")
+
+		b.WriteString(pad + "- `" + name + "`")
+
+		if a.Repeat {
+			b.WriteString(" (repeatable)")
+		}
+
+		if a.Description != "" {
+			b.WriteString(" " + a.Description)
+		}
+
+		b.WriteString("\n")
+	}
+
+	for _, f := range c.Flags {
+		fmt.Fprintf(b, "%s- `--%s` (%s) %s\n", pad, f.Name, f.Type, f.Description)
+	}
+}
+
+// writeSkillSubcommands renders a command's descendants as an indented list. An
+// agent needs the runnable leaf paths, which a flat listing cannot show.
+func writeSkillSubcommands(b *strings.Builder, commands []CommandInfo, depth int) {
+	for _, c := range commands {
+		pad := strings.Repeat("  ", depth)
+
+		b.WriteString(pad + "- `" + c.FullPath)
+
+		if usage := c.Usage(); usage != "" {
+			b.WriteString(" " + usage)
+		}
+
+		b.WriteString("`")
+
+		if c.Description != "" {
+			b.WriteString(" - " + c.Description)
+		}
+
+		b.WriteString("\n")
+
+		writeSkillDetails(b, c, pad+"  ")
+
+		writeSkillSubcommands(b, c.Subcommands, depth+1)
+	}
+
+	if depth == 0 && len(commands) > 0 {
+		b.WriteString("\n")
+	}
+}

--- a/pkg/plugin/skill_test.go
+++ b/pkg/plugin/skill_test.go
@@ -1,0 +1,356 @@
+package plugin_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ownbrewconfig "github.com/foomo/ownbrew/pkg/config"
+	"github.com/foomo/posh/pkg/config"
+	"github.com/foomo/posh/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRenderSkill(t *testing.T) {
+	out := plugin.RenderSkill(plugin.SkillMetadata{}, []plugin.SkillCommand{
+		{
+			CommandInfo: plugin.CommandInfo{
+				FullPath:    "kubectl",
+				Description: "manage kubernetes clusters",
+				Subcommands: []plugin.CommandInfo{
+					{
+						FullPath:    "kubectl <cluster>",
+						Description: "target cluster",
+						Dynamic:     true,
+						Subcommands: []plugin.CommandInfo{
+							{
+								FullPath:    "kubectl <cluster> apply",
+								Description: "apply manifests",
+								Arguments: []plugin.ArgInfo{
+									{Name: "Path", Description: "manifest directory", Repeat: true},
+								},
+								Flags: []plugin.FlagInfo{
+									{Name: "dry-run", Type: "bool", Description: "simulate the apply"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{CommandInfo: plugin.CommandInfo{FullPath: "exit", Description: "exit shell"}},
+	})
+
+	assert.Contains(t, out, "name: posh")
+	assert.Contains(t, out, "### `kubectl`")
+	assert.Contains(t, out, "manage kubernetes clusters")
+
+	// exit contributes neither prose nor structure, so it is omitted.
+	assert.NotContains(t, out, "### `exit`")
+
+	// nested descendants are rendered, deepest carrying args and flags
+	assert.Contains(t, out, "- `kubectl <cluster>` - target cluster")
+	assert.Contains(t, out, "  - `kubectl <cluster> apply [Path]...` - apply manifests")
+	assert.Contains(t, out, "`[Path]` (repeatable) manifest directory")
+	assert.Contains(t, out, "`--dry-run` (bool) simulate the apply")
+}
+
+// TestRenderSkill_UsageHeading covers the section heading: it separates a
+// command's structure from its description, and is omitted when there is no
+// structure to head.
+func TestRenderSkill_UsageHeading(t *testing.T) {
+	out := plugin.RenderSkill(plugin.SkillMetadata{}, []plugin.SkillCommand{
+		{
+			CommandInfo: plugin.CommandInfo{
+				FullPath:    "env",
+				Description: "Manage internal environment variables",
+				Subcommands: []plugin.CommandInfo{
+					{FullPath: "env list", Description: "List all environment variables"},
+				},
+			},
+			Skill: "#### Notes\n\nProcess scoped.",
+		},
+	})
+
+	// The heading sits between the description and the list, and the command's
+	// own prose keeps its heading after it.
+	assert.Regexp(t,
+		"(?s)Manage internal environment variables\n+#### Usage\n+- `env list`.*#### Notes",
+		out)
+
+	// A command whose only contribution is prose has no structure to head.
+	out = plugin.RenderSkill(plugin.SkillMetadata{}, []plugin.SkillCommand{
+		{
+			CommandInfo: plugin.CommandInfo{FullPath: "check", Description: "run checks"},
+			Skill:       "#### Notes\n\nRead the results.",
+		},
+	})
+
+	assert.NotContains(t, out, "#### Usage")
+	assert.Contains(t, out, "#### Notes")
+}
+
+// TestRenderSkill_OmitsBareLeaves covers the filter: a command carrying nothing
+// but a name and description tells an agent no more than the catalog already
+// does, so it is left out - unless it contributes prose.
+func TestRenderSkill_OmitsBareLeaves(t *testing.T) {
+	out := plugin.RenderSkill(plugin.SkillMetadata{}, []plugin.SkillCommand{
+		{CommandInfo: plugin.CommandInfo{FullPath: "bare", Description: "nothing to add"}},
+		{
+			CommandInfo: plugin.CommandInfo{FullPath: "prose", Description: "leaf with notes"},
+			Skill:       "#### Notes\n\nWorth saying.",
+		},
+		{
+			CommandInfo: plugin.CommandInfo{
+				FullPath:    "args",
+				Description: "leaf with an argument",
+				Arguments:   []plugin.ArgInfo{{Name: "Key"}},
+			},
+		},
+		{
+			CommandInfo: plugin.CommandInfo{
+				FullPath:    "flags",
+				Description: "leaf with a flag",
+				Flags:       []plugin.FlagInfo{{Name: "dry-run", Type: "bool"}},
+			},
+		},
+	})
+
+	assert.NotContains(t, out, "### `bare`")
+
+	// Any one of prose, arguments or flags is enough to keep a command.
+	assert.Contains(t, out, "### `prose`")
+	assert.Contains(t, out, "### `args")
+	assert.Contains(t, out, "### `flags`")
+
+	// Whitespace-only prose does not count as a contribution.
+	out = plugin.RenderSkill(plugin.SkillMetadata{}, []plugin.SkillCommand{
+		{CommandInfo: plugin.CommandInfo{FullPath: "blank"}, Skill: "  \n\t\n"},
+	})
+	assert.NotContains(t, out, "### `blank`")
+}
+
+func TestRenderSkill_TopLevelArgsAndFlags(t *testing.T) {
+	out := plugin.RenderSkill(plugin.SkillMetadata{}, []plugin.SkillCommand{
+		{
+			CommandInfo: plugin.CommandInfo{
+				FullPath:    "welcome",
+				Description: "print a welcome message",
+				Arguments: []plugin.ArgInfo{
+					{Name: "Name", Description: "who to greet", Optional: true},
+				},
+				Flags: []plugin.FlagInfo{
+					{Name: "loud", Type: "bool", Description: "shout it"},
+				},
+			},
+		},
+	})
+
+	// The usage line is rebuilt from the structured arguments.
+	assert.Contains(t, out, "### `welcome <Name>`")
+	assert.Contains(t, out, "- `<Name>` who to greet")
+	assert.Contains(t, out, "- `--loud` (bool) shout it")
+}
+
+func TestRenderSkill_Empty(t *testing.T) {
+	out := plugin.RenderSkill(plugin.SkillMetadata{}, nil)
+
+	assert.Contains(t, out, "## Commands")
+	assert.NotContains(t, out, "###")
+}
+
+// TestRenderSkill_Setup covers posh's own subcommands, which are documented from
+// a fixed string rather than the catalog - so they render even for a project
+// whose plugin registers no commands at all.
+func TestRenderSkill_Setup(t *testing.T) {
+	out := plugin.RenderSkill(plugin.SkillMetadata{}, nil)
+
+	assert.Contains(t, out, "## Setup")
+	assert.Contains(t, out, "`.posh.yaml`")
+	assert.Contains(t, out, "`posh require`")
+	assert.Contains(t, out, "`posh brew`")
+	assert.Contains(t, out, "`posh prompt`")
+}
+
+// TestRenderSkill_Skill covers the command.Skiller contribution: the markdown is
+// appended verbatim under the command's own heading.
+func TestRenderSkill_Skill(t *testing.T) {
+	out := plugin.RenderSkill(plugin.SkillMetadata{}, []plugin.SkillCommand{
+		{
+			CommandInfo: plugin.CommandInfo{FullPath: "cache", Description: "manage caches"},
+			// The trailing newline must not stack onto the one the renderer
+			// adds itself.
+			Skill: "#### Configuration\n\n```yaml\ncache:\n  ttl: 5m\n```\n",
+		},
+		{
+			CommandInfo: plugin.CommandInfo{
+				FullPath:    "env",
+				Description: "manage env vars",
+				Arguments:   []plugin.ArgInfo{{Name: "Key"}},
+			},
+		},
+	})
+
+	assert.Contains(t, out, "#### Configuration")
+	assert.Contains(t, out, "  ttl: 5m")
+	assert.NotContains(t, out, "```\n\n\n", "a trailing newline must not stack blank lines")
+
+	// A command contributing structure but no prose is unaffected.
+	assert.Contains(t, out, "### `env [Key]`")
+}
+
+// TestRenderSkill_Frontmatter covers the SkillMetadata overrides, including the
+// YAML-hostile description that hand-built frontmatter would corrupt.
+func TestRenderSkill_Frontmatter(t *testing.T) {
+	out := plugin.RenderSkill(plugin.SkillMetadata{
+		Name:         "acme",
+		Description:  "Drive acme: deploy, seed the DB #fast",
+		AllowedTools: []string{"Bash(posh execute:*)"},
+	}, nil)
+
+	front, _, ok := strings.Cut(strings.TrimPrefix(out, "---\n"), "---\n")
+	require.True(t, ok, "the frontmatter must be delimited")
+
+	var actual plugin.SkillMetadata
+	require.NoError(t, yaml.Unmarshal([]byte(front), &actual), "the frontmatter must be valid YAML")
+
+	assert.Equal(t, "acme", actual.Name)
+	assert.Equal(t, "Drive acme: deploy, seed the DB #fast", actual.Description)
+	assert.Equal(t, []string{"Bash(posh execute:*)"}, actual.AllowedTools)
+
+	// The hyphen form is what Claude Code reads; allowed_tools is not accepted.
+	assert.Contains(t, front, "allowed-tools:")
+}
+
+// TestRenderSkill_FrontmatterDefaults covers the zero value reproducing posh's
+// own frontmatter, with no empty allowed-tools key.
+func TestRenderSkill_FrontmatterDefaults(t *testing.T) {
+	out := plugin.RenderSkill(plugin.SkillMetadata{}, nil)
+
+	assert.Contains(t, out, "name: posh")
+	assert.Contains(t, out, "Drive this project's posh shell")
+	assert.NotContains(t, out, "allowed-tools")
+}
+
+func TestWriteSkill(t *testing.T) {
+	// A nested path exercises the parent-directory creation.
+	path := filepath.Join(t.TempDir(), "nested", "dir", "SKILL.md")
+
+	require.NoError(t, plugin.WriteSkill(path, plugin.SkillMetadata{}, []plugin.SkillCommand{
+		{
+			CommandInfo: plugin.CommandInfo{FullPath: "welcome", Description: "print a welcome message"},
+			Skill:       "#### Notes\n\nNo side effects.",
+		},
+	}))
+
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(b), "name: posh")
+	assert.Contains(t, string(b), "### `welcome`")
+}
+
+func TestWriteSkill_DefaultPath(t *testing.T) {
+	// DefaultSkillPath is relative, so write it inside a temp working dir.
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	require.NoError(t, plugin.WriteSkill("", plugin.SkillMetadata{}, nil))
+
+	_, err := os.Stat(filepath.Join(dir, plugin.DefaultSkillPath))
+	assert.NoError(t, err, "an empty path must fall back to DefaultSkillPath")
+}
+
+func TestRemoveSkill(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	require.NoError(t, plugin.WriteSkill("", plugin.SkillMetadata{}, nil))
+	require.NoError(t, plugin.RemoveSkill(""))
+
+	_, err := os.Stat(filepath.Join(dir, plugin.DefaultSkillPath))
+	assert.True(t, os.IsNotExist(err), "the skill file must be gone")
+
+	assert.NoError(t, plugin.RemoveSkill(""), "removing a missing file must be a no-op")
+}
+
+type stubLister struct{ commands []plugin.CommandInfo }
+
+func (s stubLister) Prompt(ctx context.Context, cfg config.Prompt) error   { return nil }
+func (s stubLister) Execute(ctx context.Context, args []string) error      { return nil }
+func (s stubLister) Require(ctx context.Context, cfg config.Require) error { return nil }
+func (s stubLister) Brew(ctx context.Context, cfg ownbrewconfig.Config, tags []string, dry bool) error {
+	return nil
+}
+func (s stubLister) List(ctx context.Context) []plugin.CommandInfo { return s.commands }
+
+func TestList(t *testing.T) {
+	want := []plugin.CommandInfo{{FullPath: "welcome"}}
+
+	got, err := plugin.List(t.Context(), stubLister{commands: want})
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestList_NotALister(t *testing.T) {
+	_, err := plugin.List(t.Context(), struct{}{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support the agent command catalog")
+}
+
+// stubSkillLister opts into both new interfaces.
+type stubSkillLister struct {
+	stubLister
+
+	skill []plugin.SkillCommand
+	meta  plugin.SkillMetadata
+}
+
+func (s stubSkillLister) ListSkill(ctx context.Context) []plugin.SkillCommand { return s.skill }
+func (s stubSkillLister) SkillMetadata(ctx context.Context) plugin.SkillMetadata {
+	return s.meta
+}
+
+func TestListSkill(t *testing.T) {
+	want := []plugin.SkillCommand{
+		{CommandInfo: plugin.CommandInfo{FullPath: "welcome"}, Skill: "#### Notes"},
+	}
+
+	got, err := plugin.ListSkill(t.Context(), stubSkillLister{skill: want})
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+// TestListSkill_ListerFallback covers the compatibility path: a plugin that
+// only implements Lister still yields a catalog, just without prose.
+func TestListSkill_ListerFallback(t *testing.T) {
+	got, err := plugin.ListSkill(t.Context(), stubLister{
+		commands: []plugin.CommandInfo{{FullPath: "welcome", Description: "greet"}},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "welcome", got[0].FullPath)
+	assert.Empty(t, got[0].Skill)
+}
+
+func TestListSkill_NotALister(t *testing.T) {
+	_, err := plugin.ListSkill(t.Context(), struct{}{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support the agent command catalog")
+}
+
+func TestSkillMetadataOf(t *testing.T) {
+	want := plugin.SkillMetadata{Name: "acme"}
+
+	assert.Equal(t, want, plugin.SkillMetadataOf(t.Context(), stubSkillLister{meta: want}))
+
+	// A plugin not implementing SkillMetadataer falls back to the defaults.
+	assert.Equal(t, plugin.SkillMetadata{}, plugin.SkillMetadataOf(t.Context(), stubLister{}))
+}

--- a/pkg/plugin/skillfile.go
+++ b/pkg/plugin/skillfile.go
@@ -1,0 +1,97 @@
+package plugin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// List asks plg for its command catalog, requiring the optional Lister
+// interface. It returns a descriptive error when the plugin does not implement
+// it, rather than leaving callers to repeat the type assertion.
+//
+// Resolving the plugin itself is the caller's job: the posh CLI holds its
+// provider in package state, and a downstream shell may have one in hand
+// already.
+func List(ctx context.Context, plg any) ([]CommandInfo, error) {
+	lister, ok := plg.(Lister)
+	if !ok {
+		return nil, errors.New("this project's posh shell does not support the agent command catalog")
+	}
+
+	return lister.List(ctx), nil
+}
+
+// ListSkill asks plg for its command catalog together with the extra SKILL.md
+// markdown each command contributes.
+//
+// A plugin implementing only Lister falls back to a catalog without prose, so
+// the skill still renders for shells that have not opted in.
+func ListSkill(ctx context.Context, plg any) ([]SkillCommand, error) {
+	if lister, ok := plg.(SkillLister); ok {
+		return lister.ListSkill(ctx), nil
+	}
+
+	commands, err := List(ctx, plg)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]SkillCommand, 0, len(commands))
+	for _, value := range commands {
+		ret = append(ret, SkillCommand{CommandInfo: value})
+	}
+
+	return ret, nil
+}
+
+// SkillMetadataOf returns the SKILL.md frontmatter plg supplies, or the zero
+// value - which renders posh's defaults - when it does not implement
+// SkillMetadataer.
+func SkillMetadataOf(ctx context.Context, plg any) SkillMetadata {
+	if value, ok := plg.(SkillMetadataer); ok {
+		return value.SkillMetadata(ctx)
+	}
+
+	return SkillMetadata{}
+}
+
+// WriteSkill renders commands as a Claude Code SKILL.md and writes it to path,
+// creating any missing parent directories.
+//
+// Passing an empty path writes to DefaultSkillPath. The file is regenerated in
+// full every time, so re-running after a project's commands change always
+// produces an up-to-date skill.
+func WriteSkill(path string, meta SkillMetadata, commands []SkillCommand) error {
+	path = SkillPath(path)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return errors.Wrapf(err, "failed to create directory for %s", path)
+	}
+
+	return os.WriteFile(path, []byte(RenderSkill(meta, commands)), 0o644) //nolint:gosec
+}
+
+// RemoveSkill deletes the skill file at path, falling back to DefaultSkillPath
+// when empty. A missing file is not an error, so uninstall is idempotent.
+func RemoveSkill(path string) error {
+	path = SkillPath(path)
+
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(err, "failed to remove %s", path)
+	}
+
+	return nil
+}
+
+// SkillPath resolves a user supplied skill path, falling back to
+// DefaultSkillPath when empty.
+func SkillPath(path string) string {
+	if path == "" {
+		return DefaultSkillPath
+	}
+
+	return path
+}

--- a/pkg/prompt/check/agentcheck.go
+++ b/pkg/prompt/check/agentcheck.go
@@ -1,0 +1,74 @@
+package check
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/foomo/posh/pkg/agent"
+	"github.com/foomo/posh/pkg/log"
+	"golang.org/x/sync/errgroup"
+)
+
+// Result is a single check outcome in machine-readable form. The icon and color
+// carried by Info are dropped - they are presentation, and Status carries the
+// meaning.
+type Result struct {
+	Name   string `json:"name"`
+	Note   string `json:"note"`
+	Status string `json:"status"`
+}
+
+// Results is the payload emitted by AgentCheck.
+type Results struct {
+	Checks []Result `json:"checks"`
+}
+
+// AgentCheck is a Check that emits the results as a single JSON value instead
+// of the human-formatted table rendered by DefaultCheck. It is selected in
+// agent mode so an AI coding agent gets parseable output.
+func AgentCheck(ctx context.Context, l log.Logger, checkers []Checker) error {
+	var (
+		mu     sync.Mutex
+		wg     errgroup.Group
+		values []Result
+	)
+
+	for _, checker := range checkers {
+		wg.Go(func() error {
+			cancelCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+
+			infos := checker(cancelCtx, l)
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			for _, info := range infos {
+				values = append(values, Result{
+					Name:   info.Name,
+					Note:   info.Note,
+					Status: info.Status.String(),
+				})
+			}
+
+			return nil
+		})
+	}
+
+	if err := wg.Wait(); err != nil {
+		return err
+	}
+
+	slices.SortFunc(values, func(a, b Result) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	if values == nil {
+		values = []Result{}
+	}
+
+	return agent.Encode(Results{Checks: values})
+}

--- a/pkg/prompt/check/defaultcheck.go
+++ b/pkg/prompt/check/defaultcheck.go
@@ -79,5 +79,8 @@ func DefaultCheck(ctx context.Context, l log.Logger, checkers []Checker) error {
 		return strings.Compare(a[1], b[1])
 	})
 
+	// Rendered directly rather than via agent.Table: cells here carry PTerm
+	// color escapes, and command.Check handles the agent path from the
+	// structured []Info before any of this formatting is applied.
 	return pterm.DefaultTable.WithData(data).Render()
 }

--- a/pkg/readline/extract.go
+++ b/pkg/readline/extract.go
@@ -1,0 +1,36 @@
+package readline
+
+// ExtractFlags consumes a leading run of the given flags off args, invoking
+// each one's handler as it goes, and returns the remaining pass-through args.
+//
+// It exists for commands that set cobra's DisableFlagParsing, where cobra never
+// populates the flags and so cannot deliver their values. Registering a flag on
+// the root command still matters there - without it cobra rejects the token
+// during command resolution - but registration alone does not read it. This
+// scan is what actually does.
+//
+// Stopping at the first unrecognized token is load-bearing: everything from the
+// command name onward, including flags meant for the target command (`-n` for
+// kubectl), must reach the plugin untouched. Only a leading run is consumed, so
+// a later occurrence passes through.
+//
+//	args = readline.ExtractFlags(args, map[string]func(){
+//		"--agent": func() { agent.SetFlag(true) },
+//	})
+//
+// Flag names are matched verbatim, dashes included, so a caller can accept
+// whatever spelling it registered.
+func ExtractFlags(args []string, flags map[string]func()) []string {
+	for len(args) > 0 {
+		apply, ok := flags[args[0]]
+		if !ok {
+			return args
+		}
+
+		apply()
+
+		args = args[1:]
+	}
+
+	return args
+}

--- a/pkg/readline/extract_test.go
+++ b/pkg/readline/extract_test.go
@@ -1,0 +1,84 @@
+package readline_test
+
+import (
+	"testing"
+
+	"github.com/foomo/posh/pkg/readline"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantRest  []string
+		wantCalls []string
+	}{
+		{
+			name:     "no args",
+			args:     nil,
+			wantRest: nil,
+		},
+		{
+			name:     "plain pass-through command",
+			args:     []string{"kubectl", "staging", "get", "pods"},
+			wantRest: []string{"kubectl", "staging", "get", "pods"},
+		},
+		{
+			name:      "leading flag is consumed",
+			args:      []string{"--agent", "kubectl", "staging", "apply"},
+			wantRest:  []string{"kubectl", "staging", "apply"},
+			wantCalls: []string{"--agent"},
+		},
+		{
+			name:      "flag only",
+			args:      []string{"--agent"},
+			wantRest:  []string{},
+			wantCalls: []string{"--agent"},
+		},
+		{
+			name:     "flags after the command name are not consumed",
+			args:     []string{"kubectl", "--agent", "get", "pods"},
+			wantRest: []string{"kubectl", "--agent", "get", "pods"},
+		},
+		{
+			name:      "a leading run of several flags is consumed",
+			args:      []string{"--agent", "--quiet", "kubectl", "get"},
+			wantRest:  []string{"kubectl", "get"},
+			wantCalls: []string{"--agent", "--quiet"},
+		},
+		{
+			name:      "scanning stops at the first unknown flag",
+			args:      []string{"--agent", "--unknown", "--quiet"},
+			wantRest:  []string{"--unknown", "--quiet"},
+			wantCalls: []string{"--agent"},
+		},
+		{
+			name:      "a repeated flag applies each time",
+			args:      []string{"--agent", "--agent", "welcome"},
+			wantRest:  []string{"welcome"},
+			wantCalls: []string{"--agent", "--agent"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls []string
+
+			flags := map[string]func(){
+				"--agent": func() { calls = append(calls, "--agent") },
+				"--quiet": func() { calls = append(calls, "--quiet") },
+			}
+
+			assert.Equal(t, tt.wantRest, readline.ExtractFlags(tt.args, flags))
+			assert.Equal(t, tt.wantCalls, calls)
+		})
+	}
+}
+
+func TestExtractFlags_NoFlags(t *testing.T) {
+	args := []string{"--agent", "welcome"}
+
+	// With nothing to match, every token passes through untouched.
+	assert.Equal(t, args, readline.ExtractFlags(args, nil))
+}

--- a/pkg/util/pick.go
+++ b/pkg/util/pick.go
@@ -1,0 +1,35 @@
+package util
+
+// Pick returns a when cond is true and b otherwise.
+//
+// It is the expression form of a two-branch if, for cases where the choice is
+// a value rather than control flow:
+//
+//	check: util.Pick(agent.IsAgentMode(), check.AgentCheck, check.DefaultCheck),
+//
+// Both arguments are evaluated before the call, so never use it where one
+// operand is only valid under the condition - Pick(a.HasIndex(i), a[i], "")
+// panics on the very case the guard exists for. Use PickF there, and also when
+// either side is expensive or has side effects.
+func Pick[T any](cond bool, a, b T) T {
+	if cond {
+		return a
+	}
+
+	return b
+}
+
+// PickF returns a() when cond is true and b() otherwise, evaluating only the
+// branch it takes.
+//
+// Use it where Pick would be unsafe or wasteful - when an operand is only valid
+// under the condition, is expensive, or has side effects:
+//
+//	util.PickF(a.HasIndex(i), func() string { return a[i] }, func() string { return "" })
+func PickF[T any](cond bool, a, b func() T) T {
+	if cond {
+		return a()
+	}
+
+	return b()
+}

--- a/pkg/util/pick_test.go
+++ b/pkg/util/pick_test.go
@@ -1,0 +1,55 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/foomo/posh/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPick(t *testing.T) {
+	assert.Equal(t, "a", util.Pick(true, "a", "b"))
+	assert.Equal(t, "b", util.Pick(false, "a", "b"))
+
+	// Instantiates over a non-comparable type, as the check.Check use does.
+	called := ""
+	fn := util.Pick(true,
+		func() { called = "a" },
+		func() { called = "b" },
+	)
+	fn()
+
+	assert.Equal(t, "a", called)
+}
+
+func TestPickF(t *testing.T) {
+	assert.Equal(t, "a", util.PickF(true, func() string { return "a" }, func() string { return "b" }))
+	assert.Equal(t, "b", util.PickF(false, func() string { return "a" }, func() string { return "b" }))
+}
+
+func TestPickF_OnlyEvaluatesTakenBranch(t *testing.T) {
+	var evaluated []string
+
+	got := util.PickF(true,
+		func() string { evaluated = append(evaluated, "a"); return "a" },
+		func() string { evaluated = append(evaluated, "b"); return "b" },
+	)
+
+	assert.Equal(t, "a", got)
+	assert.Equal(t, []string{"a"}, evaluated, "the untaken branch must not run")
+}
+
+// TestPickF_UnsafeForPick covers the case Pick cannot express: the false branch
+// would panic if evaluated eagerly.
+func TestPickF_UnsafeForPick(t *testing.T) {
+	var empty []string
+
+	assert.NotPanics(t, func() {
+		got := util.PickF(len(empty) > 0,
+			func() string { return empty[0] },
+			func() string { return "" },
+		)
+
+		assert.Empty(t, got)
+	})
+}


### PR DESCRIPTION
### Description

Add AI agent tooling to posh: agent-mode detection with JSONL output, a JSON command catalog, and generated Claude Code skill files.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🏃‍➡️ Performance
- [x] ✅ Tests
- [ ] 🔐 Security
- [x] 🔧 Build/CI

### Changes

- `pkg/agent` — detect AI agent harnesses via env vars (e.g. `CLAUDECODE`), the `--agent` root flag, or the `POSH_AGENT_MODE` override; includes table/tree renderers for structured output.
- `pkg/log/agentjson.go` — `log.AgentJSON` writes JSONL envelopes (`type`/`schema_version`/…) instead of PTerm prose; `internal/cmd.NewLogger` switches to it for every subcommand when agent mode is active.
- `cmd/agent.go` — new `posh agent` command group:
  - `agent catalog` prints the command catalog as JSON (`type: "posh.command_catalog"`, `schema_version: "3"`), nested and shaped to mirror grafana/gcx.
  - `agent skill install|update [path]` renders the same catalog into a Claude Code `SKILL.md` (default `.claude/skills/posh/SKILL.md`), always regenerated from the live command tree.
- `pkg/command/tree/describe.go` — `tree.Root.Describe(ctx) CommandInfo` as a peer of `Complete`/`Execute`/`Help`; dynamic (`Values`) nodes emit a `<placeholder>` with `"dynamic": true` rather than being invoked, keeping the catalog cheap and offline.
- New opt-in interfaces, added by type assertion so `Plugin`/`Command` stay unbroken: `command.Describer`, `command.Skiller` (free-form markdown appended under a command's heading), `plugin.Lister`, `plugin.SkillLister`, `plugin.SkillMetadataer` (frontmatter restricted to the Agent Skills allowlist: `name`, `description`, `allowed-tools`).
- `cmd/execute.go` — `extractExecuteFlags` scans posh's own leading flags off argv, needed because `execute` sets `DisableFlagParsing: true`; everything from the command name onward reaches the plugin untouched.
- `pkg/readline/extract.go`, `pkg/util/pick.go`, `pkg/command/payload.go` — supporting utilities.
- `pkg/prompt/check/agentcheck.go` — agent-mode prompt check.
- Scaffold (`embed/scaffold/init/`) and `docs/usage/builtins.md` updated for the new surface.
- Chore: dependency bumps, `.mise.toml`/`.golangci.yaml`/`Makefile`/`dependabot.yml` updates, standard icons in the PR template, Go Report Card badge removed.

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.

#### Notes

Access control is deliberately out of scope: posh parses commands generically and has no semantic model of arguments, so an allow/deny gate here would duplicate what the surrounding harness (Claude Code `Bash()` allow/deny, MCP wrappers, CI) already does with better visibility. Presence in the catalog or skill file does not imply a command is safe to run unattended.

There is no per-command output-format flag by design — use `POSH_AGENT_MODE=0` to force human output while inside an agent harness.