### PR TITLE
feat: add prompt theme

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -38,6 +38,7 @@ export default defineConfig({
 					{text: 'The Interactive Prompt', link: '/usage/prompt'},
 					{text: 'Built-in Commands', link: '/usage/builtins'},
 					{text: 'AI Agents', link: '/usage/agents'},
+					{text: 'Theming', link: '/usage/theming'},
 					{text: 'Configuration', link: '/usage/configuration'},
 					{text: 'Project Layout', link: '/usage/layout'},
 				],

--- a/docs/plugin/overview.md
+++ b/docs/plugin/overview.md
@@ -159,6 +159,15 @@ In practice, 90 % of plugin authoring is:
 2. Tweak `prompt.With*` options to taste
 3. Add custom checkers to `Require`/`Prompt`
 
+To let a project recolor its prompt, pass the config key through — the
+scaffolded plugin already does:
+
+```go
+prompt.WithTheme(cfg.Theme)
+```
+
+See [Theming](/usage/theming). Without it the prompt keeps its default colors.
+
 For everything else, see:
 
 - [Writing Commands](./writing-commands) — the Command interface and its optional siblings

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -20,6 +20,7 @@ Consumed by `Plugin.Prompt`.
 ```yaml
 prompt:
   title: "Posh"               # window title and banner text
+  theme: mocha                # optional Catppuccin palette for the prompt
   prefix: "posh >"            # cursor prefix; framework appends ' › '
   prefixGit: false            # show git branch & tags in prefix
   history:
@@ -35,6 +36,7 @@ prompt:
 | Field | Type | Notes |
 | --- | --- | --- |
 | `title` | string | Window/banner title. Pass-through to `prompt.OptionTitle`. |
+| `theme` | string | Optional. `mocha`, `macchiato`, `frappe` or `latte`. Colors the prompt only — omit to keep the default colors. See [Theming](/usage/theming). |
 | `prefix` | string | Static prefix. Framework appends ` › `. |
 | `prefixGit` | bool | If true, the prefix becomes `prefix (branch  tag) ›`. |
 | `history.limit` | int | Lines retained on disk. |

--- a/docs/usage/prompt.md
+++ b/docs/usage/prompt.md
@@ -105,4 +105,8 @@ Use this to surface anything the operator should know about *before* they start 
 
 ## Custom prompt options
 
-The plugin can pass arbitrary `c-bata/go-prompt` options through `prompt.WithPromptOptions(...)`, e.g. for changing the suggestion colour scheme, the maximum suggestion list length, or the keybinding for autocomplete. See `pkg/prompt/prompt.go` for the option list applied by default.
+The plugin can pass arbitrary `c-bata/go-prompt` options through `prompt.WithPromptOptions(...)`, e.g. for changing the suggestion colour scheme, the maximum suggestion list length, or the keybinding for autocomplete. See `pkg/prompt/prompt.go` for the option list applied by default. Your options are applied *after* the defaults, so they win.
+
+For colours specifically there is a shortcut: set `prompt.theme` in `.posh.yaml` to
+one of the [Catppuccin flavours](/usage/theming) and the prefix, input line and
+completion dropdown are recoloured for you. It is off unless configured.

--- a/docs/usage/theming.md
+++ b/docs/usage/theming.md
@@ -1,0 +1,80 @@
+# Theming
+
+The interactive prompt can be colored with one of the four
+[Catppuccin](https://catppuccin.com) palettes. It is **opt-in**: without the
+`prompt.theme` key, posh uses the same colors it always has.
+
+```yaml
+prompt:
+  theme: mocha
+```
+
+| Flavor | Background |
+| --- | --- |
+| `mocha` | dark |
+| `macchiato` | dark |
+| `frappe` | dark |
+| `latte` | light |
+
+There is no flag and no environment variable — the flavor is a project
+decision, so it lives in `.posh.yaml` alongside the rest of the prompt
+configuration. An unknown name fails at startup rather than falling back
+silently, so a typo surfaces immediately.
+
+## Scope
+
+Theming affects the **prompt only**: the cursor prefix, the input line and the
+completion dropdown (suggestions, descriptions and the scrollbar). Log output,
+tables, trees, the startup banner and pre-flight checks are unchanged.
+
+The dropdown is the part worth setting: go-prompt's stock colors are white on
+cyan with black-on-turquoise descriptions, which is hard to read on a light
+background. `theme: latte` is the fix.
+
+## Fidelity
+
+The prompt is built on a fork of `c-bata/go-prompt`, whose color type carries
+only the 16 ANSI slots — it has no 256-color or truecolor path, so it cannot
+render Catppuccin hex values. Colors are therefore mapped to the nearest ANSI
+slot.
+
+In practice this usually still looks right: if you run a Catppuccin *terminal*
+theme, slots 0–15 already hold Catppuccin values. When the terminal reports no
+color support at all, the theme yields the terminal's defaults.
+
+## For plugin authors
+
+The scaffolded plugin passes the key through:
+
+```go
+prompt.New(p.l,
+    prompt.WithTitle(cfg.Title),
+    prompt.WithTheme(cfg.Theme),
+    // ...
+)
+```
+
+An existing shell that predates this option keeps its current colors until
+`prompt.WithTheme(cfg.Theme)` is added to its own `plugin.go`.
+
+Options passed via `prompt.WithPromptOptions(...)` are applied after the theme,
+so they still win.
+
+The palette is also readable directly, keyed by semantic role rather than color
+name:
+
+```go
+import "github.com/foomo/posh/pkg/theme"
+
+t, err := theme.Resolve("latte")   // nil when the string is empty
+if t != nil {
+    hex := t.Hex(theme.RoleWarning)      // "#df8e1d"
+    col := t.Prompt(theme.RoleWarning)   // nearest go-prompt color
+}
+```
+
+Roles: `RoleText`, `RoleMuted`, `RolePrimary`, `RoleSecondary`, `RoleSuccess`,
+`RoleWarning`, `RoleError`, `RoleInfo`, `RoleDebug`.
+
+Custom palettes are not supported — the four Catppuccin flavors are the whole
+set.

--- a/embed/scaffold/init/$.posh.yaml
+++ b/embed/scaffold/init/$.posh.yaml
@@ -11,6 +11,9 @@ prompt:
     filename: .posh/.history
     lockFilename: .posh/.history.lock
   historySearch: true
+  ## Catppuccin palette for the prompt: mocha, macchiato, frappe or latte.
+  ## Omit to keep the default colors.
+  # theme: mocha
 
 ## Environment variables
 env:

--- a/embed/scaffold/init/$.posh/internal/plugin.go.gotext
+++ b/embed/scaffold/init/$.posh/internal/plugin.go.gotext
@@ -152,6 +152,7 @@ func (p *Plugin) Prompt(ctx context.Context, cfg config.Prompt) error {
 	sh, err := prompt.New(p.l,
 		prompt.WithContext(ctx),
 		prompt.WithTitle(cfg.Title),
+		prompt.WithTheme(cfg.Theme),
 		prompt.WithPrefix(cfg.Prefix),
 		prompt.WithPrefixGit(cfg.PrefixGit),
 		prompt.WithAliases(cfg.Aliases),

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/foomo/ownbrew v0.3.0
 	github.com/go-git/go-git/v6 v6.0.0-alpha.5
 	github.com/gofrs/flock v0.13.0
+	github.com/gookit/color v1.6.1
 	github.com/invopop/jsonschema v0.14.0
 	github.com/joho/godotenv v1.5.1
 	github.com/kubescape/go-git-url v0.0.32
@@ -64,7 +65,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gookit/color v1.6.1 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kevinburke/ssh_config v1.6.0 // indirect

--- a/pkg/config/prompt.go
+++ b/pkg/config/prompt.go
@@ -2,7 +2,9 @@ package config
 
 type (
 	Prompt struct {
-		Title         string            `json:"title" yaml:"title"`
+		Title string `json:"title" yaml:"title"`
+		// Theme selects a Catppuccin palette for the prompt: mocha, macchiato, frappe or latte
+		Theme         string            `json:"theme" yaml:"theme"`
 		Prefix        string            `json:"prefix" yaml:"prefix"`
 		PrefixGit     bool              `json:"prefixGit" yaml:"prefixGit"`
 		History       PromptHistory     `json:"history" yaml:"history"`

--- a/pkg/prompt/export_test.go
+++ b/pkg/prompt/export_test.go
@@ -1,0 +1,12 @@
+package prompt
+
+import (
+	"github.com/c-bata/go-prompt"
+)
+
+// ThemeOptions exposes the theme's color options for the black-box
+// prompt_test package, so a test can assert that an unconfigured prompt adds
+// none of them without having to start an interactive session.
+func ThemeOptions(p *Prompt) []prompt.Option {
+	return p.themeOptions()
+}

--- a/pkg/prompt/goprompt/types.go
+++ b/pkg/prompt/goprompt/types.go
@@ -9,6 +9,32 @@ type (
 	Suggest  = prompt.Suggest
 	Suggests = []prompt.Suggest
 	Document = prompt.Document
+	// Color is go-prompt's color type. It carries only the 16 ANSI slots below
+	// — the underlying writer maps them through fixed SGR tables and has no
+	// 256-color or truecolor path — so the interactive prompt cannot render
+	// arbitrary hex.
+	Color = prompt.Color
+)
+
+// The 16 ANSI slots go-prompt can render, low intensity first.
+const (
+	DefaultColor = prompt.DefaultColor
+	Black        = prompt.Black
+	DarkRed      = prompt.DarkRed
+	DarkGreen    = prompt.DarkGreen
+	Brown        = prompt.Brown
+	DarkBlue     = prompt.DarkBlue
+	Purple       = prompt.Purple
+	Cyan         = prompt.Cyan
+	LightGray    = prompt.LightGray
+	DarkGray     = prompt.DarkGray
+	Red          = prompt.Red
+	Green        = prompt.Green
+	Yellow       = prompt.Yellow
+	Blue         = prompt.Blue
+	Fuchsia      = prompt.Fuchsia
+	Turquoise    = prompt.Turquoise
+	White        = prompt.White
 )
 
 var (

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -17,6 +17,7 @@ import (
 	"github.com/foomo/posh/pkg/prompt/history"
 	"github.com/foomo/posh/pkg/readline"
 	"github.com/foomo/posh/pkg/shell"
+	"github.com/foomo/posh/pkg/theme"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/lithammer/fuzzysearch/fuzzy"
@@ -44,6 +45,7 @@ type (
 		historySearch bool
 		commands      command.Commands
 		aliases       map[string]string
+		theme         *theme.Theme
 		// inputRegex - split cmd into args
 		promptOptions []prompt.Option
 	}
@@ -152,6 +154,21 @@ func WithPromptOptions(v ...prompt.Option) Option {
 func WithHistorySearch(v bool) Option {
 	return func(o *Prompt) error {
 		o.historySearch = v
+		return nil
+	}
+}
+
+// WithTheme colors the prompt using a Catppuccin flavor: mocha, macchiato,
+// frappe or latte. An empty value leaves the prompt's default colors alone.
+func WithTheme(v string) Option {
+	return func(o *Prompt) error {
+		value, err := theme.Resolve(v)
+		if err != nil {
+			return err
+		}
+
+		o.theme = value
+
 		return nil
 	}
 }
@@ -285,6 +302,11 @@ func (s *Prompt) Run() error {
 		}))
 	}
 
+	// Appended rather than folded into baseOptions so that an unconfigured
+	// shell keeps exactly the colors it had before theming existed: with no
+	// theme, not one color option changes.
+	baseOptions = append(baseOptions, s.themeOptions()...)
+
 	p := prompt.New(
 		s.execute,
 		s.complete,
@@ -320,6 +342,35 @@ func (s *Prompt) Run() error {
 // ------------------------------------------------------------------------------------------------
 // ~ Private methods
 // ------------------------------------------------------------------------------------------------
+
+// themeOptions returns the color options for the configured theme, or nothing
+// at all when none is configured.
+//
+// go-prompt is limited to the 16 ANSI colors — its color type has no 256-color
+// or truecolor path — so these are nearest-slot approximations rather than
+// exact Catppuccin values. In practice that usually still lands right: a user
+// running a Catppuccin terminal theme has those slots remapped already.
+func (s *Prompt) themeOptions() []prompt.Option {
+	if s.theme == nil {
+		return nil
+	}
+
+	return []prompt.Option{
+		prompt.OptionPrefixTextColor(s.theme.Prompt(theme.RolePrimary)),
+		prompt.OptionInputTextColor(s.theme.Prompt(theme.RoleText)),
+		prompt.OptionSuggestionTextColor(s.theme.Prompt(theme.RoleText)),
+		prompt.OptionSuggestionBGColor(s.theme.Prompt(theme.RoleMuted)),
+		prompt.OptionSelectedSuggestionTextColor(s.theme.Prompt(theme.RoleText)),
+		prompt.OptionSelectedSuggestionBGColor(s.theme.Prompt(theme.RolePrimary)),
+		prompt.OptionDescriptionTextColor(s.theme.Prompt(theme.RoleMuted)),
+		prompt.OptionDescriptionBGColor(s.theme.Prompt(theme.RoleMuted)),
+		prompt.OptionSelectedDescriptionTextColor(s.theme.Prompt(theme.RoleText)),
+		prompt.OptionSelectedDescriptionBGColor(s.theme.Prompt(theme.RolePrimary)),
+		prompt.OptionPreviewSuggestionTextColor(s.theme.Prompt(theme.RoleSuccess)),
+		prompt.OptionScrollbarThumbColor(s.theme.Prompt(theme.RoleMuted)),
+		prompt.OptionScrollbarBGColor(s.theme.Prompt(theme.RoleMuted)),
+	}
+}
 
 func (s *Prompt) alias(input string, aliases map[string]string) string {
 	for key, value := range aliases {

--- a/pkg/prompt/theme_test.go
+++ b/pkg/prompt/theme_test.go
@@ -1,0 +1,38 @@
+package prompt_test
+
+import (
+	"testing"
+
+	"github.com/foomo/posh/pkg/log"
+	"github.com/foomo/posh/pkg/prompt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithThemeUnconfigured pins the opt-in contract: an empty value is not an
+// error and leaves the prompt exactly as it was before theming existed.
+func TestWithThemeUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	subject, err := prompt.New(log.NewFmt(), prompt.WithTheme(""))
+	require.NoError(t, err)
+	assert.Empty(t, prompt.ThemeOptions(subject), "an unconfigured prompt must add no color options")
+}
+
+func TestWithThemeConfigured(t *testing.T) {
+	t.Parallel()
+
+	subject, err := prompt.New(log.NewFmt(), prompt.WithTheme("latte"))
+	require.NoError(t, err)
+	assert.Len(t, prompt.ThemeOptions(subject), 13)
+}
+
+// TestWithThemeRejectsUnknown surfaces a typo in .posh.yaml at startup rather
+// than rendering a different theme than the one asked for.
+func TestWithThemeRejectsUnknown(t *testing.T) {
+	t.Parallel()
+
+	_, err := prompt.New(log.NewFmt(), prompt.WithTheme("nord"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nord")
+}

--- a/pkg/theme/ansi16.go
+++ b/pkg/theme/ansi16.go
@@ -1,0 +1,65 @@
+package theme
+
+import (
+	"github.com/foomo/posh/pkg/prompt/goprompt"
+)
+
+// The 16-color mapping is hand-written rather than computed.
+//
+// gookit's RGBColor.Basic() picks the nearest basic color by RGB distance,
+// which for Catppuccin's low-saturation palette collapses almost every Mocha
+// role onto white — nine roles rendered identically, and no visible difference
+// between the dark and light flavors. Since go-prompt is permanently limited
+// to these 16 slots, that is precisely where the distinctions matter most, so
+// they are chosen by hand.
+//
+// Slots are picked to match Catppuccin's own published ANSI mapping
+// (the `ansiColors` block of catppuccin/palette), so that on a terminal
+// running a Catppuccin theme the prompt renders the intended colors exactly.
+// That mapping puts each palette's signature colors in the *normal* slots
+// (30-37) — Mocha's ANSI red is #f38ba8, the same value as its `red` — and
+// uses the bright slots (90-97) for variant shades. Both dark and light
+// flavors therefore use normal slots for the semantic roles; only the
+// grays differ, since those must contrast with opposite backgrounds.
+//
+// The exceptions are deliberate:
+//
+//   - Primary maps to magenta even though Catppuccin's ANSI magenta is `pink`
+//     rather than `mauve`. Magenta is the closest slot in hue, and picking by
+//     RGB distance instead would land on white and erase the role.
+//   - Secondary maps to blue and Info to cyan, matching `sapphire` and `sky`
+//     by hue; both are near-neighbours of the exact ANSI values.
+//
+// The three dark flavors share a mapping: they differ only in shade, which 16
+// colors cannot express anyway.
+
+var promptDark = map[Role]goprompt.Color{
+	RoleText:      goprompt.White,     // bright white: brightest against a dark bg
+	RoleMuted:     goprompt.DarkGray,  // bright black
+	RolePrimary:   goprompt.Purple,    // magenta
+	RoleSecondary: goprompt.DarkBlue,  // blue
+	RoleSuccess:   goprompt.DarkGreen, // green
+	RoleWarning:   goprompt.Brown,     // yellow
+	RoleError:     goprompt.DarkRed,   // red
+	RoleInfo:      goprompt.Cyan,      // cyan
+	RoleDebug:     goprompt.DarkGray,  // bright black
+}
+
+var promptLight = map[Role]goprompt.Color{
+	RoleText:      goprompt.Black,     // darkest against a light bg
+	RoleMuted:     goprompt.LightGray, // white: dimmed, but still legible
+	RolePrimary:   goprompt.Purple,    // magenta
+	RoleSecondary: goprompt.Cyan,      // cyan
+	RoleSuccess:   goprompt.DarkGreen, // green
+	RoleWarning:   goprompt.Brown,     // yellow
+	RoleError:     goprompt.DarkRed,   // red
+	RoleInfo:      goprompt.DarkBlue,  // blue
+	RoleDebug:     goprompt.LightGray, // white
+}
+
+var promptColors = map[Flavor]map[Role]goprompt.Color{
+	FlavorMocha:     promptDark,
+	FlavorMacchiato: promptDark,
+	FlavorFrappe:    promptDark,
+	FlavorLatte:     promptLight,
+}

--- a/pkg/theme/capability.go
+++ b/pkg/theme/capability.go
@@ -1,0 +1,50 @@
+package theme
+
+import (
+	"github.com/gookit/color"
+)
+
+// Capability is how much color the terminal can render.
+type Capability int
+
+const (
+	CapabilityNone Capability = iota
+	Capability16
+	Capability256
+	CapabilityTrueColor
+)
+
+// DetectCapability reports what the current terminal supports.
+//
+// This exists because neither pterm nor gookit degrades on its own: gookit's
+// RenderCode only checks whether color is enabled at all, and otherwise emits
+// whatever escape it was handed. A truecolor sequence therefore reaches a
+// 256-color terminal verbatim and renders as garbage. Every color this package
+// emits is chosen against this value instead.
+func DetectCapability() Capability {
+	switch {
+	case !color.SupportColor():
+		return CapabilityNone
+	case color.SupportTrueColor():
+		return CapabilityTrueColor
+	case color.Support256Color():
+		return Capability256
+	default:
+		return Capability16
+	}
+}
+
+func (c Capability) String() string {
+	switch c {
+	case CapabilityNone:
+		return "none"
+	case Capability16:
+		return "16"
+	case Capability256:
+		return "256"
+	case CapabilityTrueColor:
+		return "truecolor"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/theme/flavor.go
+++ b/pkg/theme/flavor.go
@@ -1,0 +1,99 @@
+package theme
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Flavor is one of the four Catppuccin palettes.
+type Flavor string
+
+const (
+	FlavorMocha     Flavor = "mocha"
+	FlavorMacchiato Flavor = "macchiato"
+	FlavorFrappe    Flavor = "frappe"
+	FlavorLatte     Flavor = "latte"
+)
+
+// DefaultFlavor is used when nothing selects a flavor and auto-detection does
+// not produce an answer.
+const DefaultFlavor = FlavorMocha
+
+// Flavors returns every flavor, dark ones first.
+func Flavors() []Flavor {
+	return []Flavor{FlavorMocha, FlavorMacchiato, FlavorFrappe, FlavorLatte}
+}
+
+// ParseFlavor resolves a flavor name case-insensitively.
+func ParseFlavor(v string) (Flavor, error) {
+	switch f := Flavor(strings.ToLower(strings.TrimSpace(v))); f {
+	case FlavorMocha, FlavorMacchiato, FlavorFrappe, FlavorLatte:
+		return f, nil
+	default:
+		return "", errors.Errorf("unknown theme flavor %q (expected one of: mocha, macchiato, frappe, latte)", v)
+	}
+}
+
+func (f Flavor) String() string {
+	return string(f)
+}
+
+// IsDark reports whether the flavor is intended for a dark terminal
+// background. Only Latte is light.
+func (f Flavor) IsDark() bool {
+	return f != FlavorLatte
+}
+
+// palettes holds the hex value of every role, per flavor.
+//
+// Hex is the only hand-written color data in this package: the 256- and
+// 16-color projections are computed from it at construction time, so the tiers
+// cannot disagree with each other. Values are verified against upstream
+// catppuccin/palette palette.json.
+var palettes = map[Flavor]map[Role]string{
+	FlavorMocha: {
+		RoleText:      "#cdd6f4", // Text
+		RoleMuted:     "#7f849c", // Overlay1
+		RolePrimary:   "#cba6f7", // Mauve
+		RoleSecondary: "#74c7ec", // Sapphire
+		RoleSuccess:   "#a6e3a1", // Green
+		RoleWarning:   "#f9e2af", // Yellow
+		RoleError:     "#f38ba8", // Red
+		RoleInfo:      "#89dceb", // Sky
+		RoleDebug:     "#6c7086", // Overlay0
+	},
+	FlavorMacchiato: {
+		RoleText:      "#cad3f5",
+		RoleMuted:     "#8087a2",
+		RolePrimary:   "#c6a0f6",
+		RoleSecondary: "#7dc4e4",
+		RoleSuccess:   "#a6da95",
+		RoleWarning:   "#eed49f",
+		RoleError:     "#ed8796",
+		RoleInfo:      "#91d7e3",
+		RoleDebug:     "#6e738d",
+	},
+	FlavorFrappe: {
+		RoleText:      "#c6d0f5",
+		RoleMuted:     "#838ba7",
+		RolePrimary:   "#ca9ee6",
+		RoleSecondary: "#85c1dc",
+		RoleSuccess:   "#a6d189",
+		RoleWarning:   "#e5c890",
+		RoleError:     "#e78284",
+		RoleInfo:      "#99d1db",
+		RoleDebug:     "#737994",
+	},
+	FlavorLatte: {
+		RoleText:      "#4c4f69",
+		RoleMuted:     "#8c8fa1",
+		RolePrimary:   "#8839ef",
+		RoleSecondary: "#209fb5",
+		RoleSuccess:   "#40a02b",
+		RoleWarning:   "#df8e1d",
+		RoleError:     "#d20f39",
+		RoleInfo:      "#04a5e5",
+		RoleDebug:     "#9ca0b0",
+	},
+}

--- a/pkg/theme/resolve.go
+++ b/pkg/theme/resolve.go
@@ -1,0 +1,29 @@
+package theme
+
+import (
+	"github.com/gookit/color"
+)
+
+// Resolve builds the theme for a configured flavor name.
+//
+// An empty name means no theme was configured and returns nil, which callers
+// treat as "keep the previous, unthemed behavior" rather than as an error. An
+// unrecognized name is an error: it is a typo in something the user wrote, and
+// silently rendering a different theme would hide it.
+func Resolve(flavor string) (*Theme, error) {
+	if flavor == "" {
+		return nil, nil //nolint:nilnil // no theme configured is not a failure
+	}
+
+	parsed, err := ParseFlavor(flavor)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := []Option{WithFlavor(parsed)}
+	if !color.SupportColor() {
+		opts = append(opts, WithCapability(CapabilityNone))
+	}
+
+	return New(opts...)
+}

--- a/pkg/theme/role.go
+++ b/pkg/theme/role.go
@@ -1,0 +1,55 @@
+package theme
+
+// Role is a semantic slot in a palette rather than a Catppuccin color name.
+//
+// Call sites ask for meaning ("this is an error") instead of a color, so
+// swapping the palette — in particular flipping between a dark and a light
+// flavor — needs no call-site edits. It also keeps the palette data unexported:
+// naming Mauve in a public API would promise a distinction the 16-color prompt
+// tier cannot keep, since Mocha's Mauve and Lavender collapse to the same
+// ANSI slot.
+type Role int
+
+const (
+	RoleText Role = iota
+	RoleMuted
+	RolePrimary
+	RoleSecondary
+	RoleSuccess
+	RoleWarning
+	RoleError
+	RoleInfo
+	RoleDebug
+)
+
+// roleNames is indexed by Role and must stay in sync with the constants above.
+var roleNames = [...]string{
+	RoleText:      "text",
+	RoleMuted:     "muted",
+	RolePrimary:   "primary",
+	RoleSecondary: "secondary",
+	RoleSuccess:   "success",
+	RoleWarning:   "warning",
+	RoleError:     "error",
+	RoleInfo:      "info",
+	RoleDebug:     "debug",
+}
+
+// Roles returns every role, in declaration order. Used by tests to assert that
+// each palette covers the full set.
+func Roles() []Role {
+	ret := make([]Role, 0, len(roleNames))
+	for i := range roleNames {
+		ret = append(ret, Role(i))
+	}
+
+	return ret
+}
+
+func (r Role) String() string {
+	if int(r) < 0 || int(r) >= len(roleNames) {
+		return "unknown"
+	}
+
+	return roleNames[r]
+}

--- a/pkg/theme/theme.go
+++ b/pkg/theme/theme.go
@@ -1,0 +1,123 @@
+// Package theme provides the Catppuccin palettes used to color the
+// interactive prompt.
+//
+// It is opt-in: a project selects a flavor via the `prompt.theme` key in
+// .posh.yaml, and without it posh keeps its previous, unthemed colors.
+package theme
+
+import (
+	"github.com/foomo/posh/pkg/prompt/goprompt"
+	"github.com/pkg/errors"
+)
+
+type (
+	// Theme is a resolved palette: a flavor plus the terminal capability its
+	// colors have been projected onto.
+	Theme struct {
+		flavor     Flavor
+		capability Capability
+		hex        map[Role]string
+	}
+	Option func(*Theme) error
+)
+
+// ------------------------------------------------------------------------------------------------
+// ~ Options
+// ------------------------------------------------------------------------------------------------
+
+func WithFlavor(v Flavor) Option {
+	return func(o *Theme) error {
+		if _, ok := palettes[v]; !ok {
+			return errors.Errorf("unknown theme flavor %q", v)
+		}
+
+		o.flavor = v
+
+		return nil
+	}
+}
+
+// WithCapability pins the color tier instead of detecting it. Intended for
+// tests: production code should let New detect the terminal.
+func WithCapability(v Capability) Option {
+	return func(o *Theme) error {
+		o.capability = v
+		return nil
+	}
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Constructor
+// ------------------------------------------------------------------------------------------------
+
+func New(opts ...Option) (*Theme, error) {
+	inst := &Theme{
+		flavor:     DefaultFlavor,
+		capability: DetectCapability(),
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			if err := opt(inst); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	palette, ok := palettes[inst.flavor]
+	if !ok {
+		return nil, errors.Errorf("no palette for flavor %q", inst.flavor)
+	}
+
+	inst.hex = palette
+
+	return inst, nil
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Getter
+// ------------------------------------------------------------------------------------------------
+
+func (t *Theme) Flavor() Flavor {
+	return t.flavor
+}
+
+func (t *Theme) Capability() Capability {
+	return t.capability
+}
+
+func (t *Theme) IsDark() bool {
+	return t.flavor.IsDark()
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Public methods
+// ------------------------------------------------------------------------------------------------
+
+// Hex returns the role's exact Catppuccin value.
+//
+// The prompt cannot render it — see Prompt — but it is the palette's source of
+// truth and is exposed for commands that print their own colors.
+func (t *Theme) Hex(r Role) string {
+	return t.hex[r]
+}
+
+// Prompt returns the role as one of go-prompt's 16 ANSI colors.
+//
+// The prompt is capped at 16 colors, so this is an approximation. It is
+// hand-mapped rather than derived: gookit's nearest-basic conversion collapses
+// almost every Mocha role onto white, which would erase both the roles and the
+// dark/light distinction in precisely the tier that cannot afford to lose them.
+func (t *Theme) Prompt(r Role) goprompt.Color {
+	if t.capability == CapabilityNone {
+		return goprompt.DefaultColor
+	}
+
+	if m, ok := promptColors[t.flavor]; ok {
+		if c, ok := m[r]; ok {
+			return c
+		}
+	}
+
+	return goprompt.DefaultColor
+}

--- a/pkg/theme/theme_test.go
+++ b/pkg/theme/theme_test.go
@@ -1,0 +1,192 @@
+// Tests in this package mutate gookit's detected color level, so they save and
+// restore it in t.Cleanup and must not call t.Parallel — a leaked mutation
+// surfaces as a confusing failure in an unrelated package.
+package theme_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/foomo/posh/pkg/prompt/goprompt"
+	"github.com/foomo/posh/pkg/theme"
+	"github.com/gookit/color"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var hexRe = regexp.MustCompile(`^#[0-9a-f]{6}$`)
+
+// forceLevel pins gookit's color level for the duration of a test.
+func forceLevel(t *testing.T, level color.Level) {
+	t.Helper()
+
+	prevLevel, prevEnable := color.TermColorLevel(), color.Enable
+	color.Enable = true
+
+	color.ForceSetColorLevel(level)
+
+	t.Cleanup(func() {
+		color.ForceSetColorLevel(prevLevel)
+
+		color.Enable = prevEnable
+	})
+}
+
+func TestPalettesAreComplete(t *testing.T) {
+	forceLevel(t, color.Level256)
+
+	for _, flavor := range theme.Flavors() {
+		t.Run(flavor.String(), func(t *testing.T) {
+			subject, err := theme.New(theme.WithFlavor(flavor))
+			require.NoError(t, err)
+
+			for _, role := range theme.Roles() {
+				assert.Regexp(t, hexRe, subject.Hex(role), "role %s has no hex", role)
+				assert.NotEqual(t, "unknown", role.String())
+			}
+		})
+	}
+}
+
+// TestPromptColorsAreComplete covers the tier the prompt actually renders: a
+// missing entry would silently fall back to the terminal default.
+func TestPromptColorsAreComplete(t *testing.T) {
+	forceLevel(t, color.Level256)
+
+	for _, flavor := range theme.Flavors() {
+		t.Run(flavor.String(), func(t *testing.T) {
+			subject, err := theme.New(theme.WithFlavor(flavor))
+			require.NoError(t, err)
+
+			for _, role := range theme.Roles() {
+				assert.NotEqual(t, goprompt.DefaultColor, subject.Prompt(role),
+					"role %s falls back to the default color", role)
+			}
+		})
+	}
+}
+
+// TestPromptColorsMatchCatppuccinANSI pins the 16-color mapping to Catppuccin's
+// own published ANSI slots (the `ansiColors` block of catppuccin/palette).
+//
+// That mapping puts each palette's signature colors in the *normal* SGR slots
+// and variant shades in the bright ones, so a role mapped to a bright slot
+// renders a different shade than intended on a Catppuccin terminal — which is
+// exactly the setup this tier exists to serve. An earlier version of the table
+// used bright slots throughout for the dark flavors and was one shade off on
+// six of the nine roles.
+func TestPromptColorsMatchCatppuccinANSI(t *testing.T) {
+	forceLevel(t, color.Level256)
+
+	// The roles whose Catppuccin color IS the normal ANSI slot for that hue,
+	// so the expectation is exact rather than nearest-neighbour.
+	exact := map[theme.Role]goprompt.Color{
+		theme.RoleSuccess: goprompt.DarkGreen, // green
+		theme.RoleWarning: goprompt.Brown,     // yellow
+		theme.RoleError:   goprompt.DarkRed,   // red
+	}
+
+	for _, flavor := range theme.Flavors() {
+		t.Run(flavor.String(), func(t *testing.T) {
+			subject, err := theme.New(theme.WithFlavor(flavor))
+			require.NoError(t, err)
+
+			for role, want := range exact {
+				assert.Equal(t, want, subject.Prompt(role),
+					"role %s must use the normal ANSI slot so a Catppuccin terminal renders the exact palette color", role)
+			}
+		})
+	}
+}
+
+// TestFlavorsDiffer pins the user-visible promise: a light flavor must not
+// render like a dark one.
+func TestFlavorsDiffer(t *testing.T) {
+	forceLevel(t, color.Level256)
+
+	mocha, err := theme.New(theme.WithFlavor(theme.FlavorMocha))
+	require.NoError(t, err)
+
+	latte, err := theme.New(theme.WithFlavor(theme.FlavorLatte))
+	require.NoError(t, err)
+
+	assert.True(t, mocha.IsDark())
+	assert.False(t, latte.IsDark())
+
+	for _, role := range []theme.Role{theme.RoleText, theme.RolePrimary, theme.RoleError, theme.RoleMuted} {
+		assert.NotEqual(t, mocha.Hex(role), latte.Hex(role), "role %s should differ between flavors", role)
+	}
+
+	// The text role in particular has to flip, or the input line is illegible
+	// on one of the two backgrounds.
+	assert.NotEqual(t, mocha.Prompt(theme.RoleText), latte.Prompt(theme.RoleText))
+}
+
+func TestNoColorYieldsDefaults(t *testing.T) {
+	forceLevel(t, color.Level256)
+
+	subject, err := theme.New(theme.WithFlavor(theme.FlavorMocha), theme.WithCapability(theme.CapabilityNone))
+	require.NoError(t, err)
+
+	for _, role := range theme.Roles() {
+		assert.Equal(t, goprompt.DefaultColor, subject.Prompt(role))
+	}
+}
+
+func TestParseFlavor(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    theme.Flavor
+		wantErr bool
+	}{
+		{name: "lowercase", input: "mocha", want: theme.FlavorMocha},
+		{name: "mixed case", input: "Latte", want: theme.FlavorLatte},
+		{name: "surrounding space", input: "  frappe  ", want: theme.FlavorFrappe},
+		{name: "macchiato", input: "macchiato", want: theme.FlavorMacchiato},
+		{name: "unknown", input: "solarized", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := theme.ParseFlavor(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestResolveUnconfigured is the whole opt-in contract: no flavor means no
+// theme, which callers use to keep their previous colors untouched.
+func TestResolveUnconfigured(t *testing.T) {
+	forceLevel(t, color.Level256)
+
+	subject, err := theme.Resolve("")
+	require.NoError(t, err)
+	assert.Nil(t, subject)
+}
+
+func TestResolveConfigured(t *testing.T) {
+	forceLevel(t, color.Level256)
+
+	subject, err := theme.Resolve("latte")
+	require.NoError(t, err)
+	require.NotNil(t, subject)
+	assert.Equal(t, theme.FlavorLatte, subject.Flavor())
+}
+
+// TestResolveRejectsUnknown covers a typo in something the user wrote: it must
+// surface rather than silently render a different theme.
+func TestResolveRejectsUnknown(t *testing.T) {
+	forceLevel(t, color.Level256)
+
+	_, err := theme.Resolve("nord")
+	require.Error(t, err)
+}

--- a/posh.schema.json
+++ b/posh.schema.json
@@ -43,6 +43,10 @@
         "title": {
           "type": "string"
         },
+        "theme": {
+          "type": "string",
+          "description": "Theme selects a Catppuccin palette for the prompt: mocha, macchiato, frappe or latte"
+        },
         "prefix": {
           "type": "string"
         },


### PR DESCRIPTION
### Description

Add an opt-in `prompt.theme` key that recolors the interactive prompt with one of the four Catppuccin flavors.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] 🏃‍➡️ Performance
- [x] ✅ Tests
- [ ] 🔐 Security
- [ ] 🔧 Build/CI

### Changes

- New `pkg/theme` package: `Flavor` (mocha, macchiato, frappe, latte), semantic `Role`s (text, muted, primary, secondary, success, warning, error, info, debug), terminal `Capability` detection and `Resolve(flavor)`.
- `prompt.WithTheme(cfg.Theme)` colors the prefix, input line and completion dropdown (suggestions, descriptions, scrollbar). Applied *after* the base options and only when a theme is configured, so an unthemed shell keeps byte-identical colors.
- `config.Prompt.Theme` + `posh.schema.json`; commented example in the scaffolded `.posh.yaml`; scaffolded `plugin.go` passes the key through.
- `goprompt` now re-exports `Color` and the 16 ANSI slots — go-prompt has no 256-color/truecolor path, so palette values are hand-mapped to the nearest slot rather than derived (gookit's nearest-basic collapses most Mocha roles onto white).
- Empty theme → nil, unknown flavor → startup error, no color support → `DefaultColor`.
- `github.com/gookit/color` promoted from indirect to direct dependency.
- Docs: new `docs/usage/theming.md` (scope, fidelity caveat, plugin-author usage), plus updates to `configuration.md`, `prompt.md`, `plugin/overview.md` and the VitePress sidebar.

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.

#### Notes

Theming is prompt-only — log output, tables, trees, the banner and pre-flight checks are untouched. Existing downstream shells keep their current colors until they add `prompt.WithTheme(cfg.Theme)` to their own `plugin.go`. Custom palettes are out of scope; the four flavors are the whole set.